### PR TITLE
Issue #29 ExprAnon to typechecker::Expr translation functions

### DIFF
--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -63,7 +63,13 @@ pub enum Const {
     expr: ExprCid
   },
   /// opaque
-  Opaque { name: Name, lvl: Vec<Name>, typ: ExprCid, expr: ExprCid, safe: bool },
+  Opaque {
+    name: Name,
+    lvl: Vec<Name>,
+    typ: ExprCid,
+    expr: ExprCid,
+    safe: bool
+  },
   /// def
   Definition {
     name: Name,
@@ -91,7 +97,6 @@ pub enum Const {
     lvl: Vec<Name>,
     ind: ConstCid,
     typ: ExprCid,
-    idx: Nat,
     param: Nat,
     field: Nat,
     safe: bool,
@@ -210,18 +215,17 @@ impl Const {
           }.store(env)?;
         Ok(ConstCid { anon, meta })
       }
-      Const::Constructor { name, lvl, ind, typ, idx, param, field, safe } => {
+      Const::Constructor { name, lvl, ind, typ, param, field, safe } => {
         let anon = ConstAnon::Constructor{
+          name: name.clone(),
           lvl: lvl.len().into(),
           ind: ind.anon,
           typ: typ.anon,
-          idx: idx.clone(),
           param: param.clone(),
           field: field.clone(),
           safe: *safe,
         }.store(env)?;
         let meta = ConstMeta::Constructor{
-          name: name.clone(),
           lvl: lvl.clone(),
           ind: ind.meta,
           typ: typ.meta,
@@ -323,7 +327,6 @@ pub enum ConstMeta {
     ctors: Vec<ExprMetaCid>,
   },
   Constructor {
-    name: Name,
     lvl: Vec<Name>,
     ind: ConstMetaCid,
     typ: ExprMetaCid,
@@ -404,11 +407,10 @@ pub enum ConstAnon {
     nest: bool,
   },
   Constructor {
-    // index: Nat,
+    name: Name,
     lvl: Nat,
     ind: ConstAnonCid,
     typ: ExprAnonCid,
-    idx: Nat,
     param: Nat,
     field: Nat,
     safe: bool,

--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -49,9 +49,18 @@ pub enum QuotKind {
 #[derive(Clone, Debug)]
 pub enum Const {
   /// axiom
-  Axiom { name: Name, lvl: Vec<Name>, typ: Box<Expr> },
+  Axiom {
+    name: Name,
+    lvl: Vec<Name>,
+    typ: Box<Expr>
+  },
   /// theorem
-  Theorem { name: Name, lvl: Vec<Name>, typ: Box<Expr>, expr: Box<Expr> },
+  Theorem {
+    name: Name,
+    lvl: Vec<Name>,
+    typ: Box<Expr>,
+    expr: Box<Expr>
+  },
   /// opaque
   Opaque {
     name: Name,
@@ -115,62 +124,66 @@ impl Const {
       Const::Axiom { name, lvl, typ } => {
         let typ_cid = typ.clone().store(env)?;
         let anon =
-          ConstAnon::Axiom(lvl.len().into(), typ_cid.anon).store(env)?;
-        let meta = ConstMeta::Axiom(name.clone(), lvl.clone(), typ_cid.meta)
-          .store(env)?;
+          ConstAnon::Axiom {
+            lvl: lvl.len().into(),
+            typ: typ_cid.anon
+          }.store(env)?;
+        let meta = ConstMeta::Axiom{
+          name: name.clone(),
+          lvl: lvl.clone(),
+          typ: typ_cid.meta
+        }.store(env)?;
         Ok(ConstCid { anon, meta })
       }
       Const::Theorem { name, lvl, typ, expr } => {
         let typ_cid = typ.clone().store(env)?;
         let expr_cid = expr.clone().store(env)?;
         let anon =
-          ConstAnon::Theorem(lvl.len().into(), typ_cid.anon, expr_cid.anon)
-            .store(env)?;
-        let meta = ConstMeta::Theorem(
-          name.clone(),
-          lvl.clone(),
-          typ_cid.meta,
-          expr_cid.meta,
-        )
-        .store(env)?;
+          ConstAnon::Theorem{
+            lvl: lvl.len().into(),
+            typ: typ_cid.anon,
+            expr: expr_cid.anon
+          }.store(env)?;
+        let meta = ConstMeta::Theorem{
+          name: name.clone(),
+          lvl: lvl.clone(),
+          typ: typ_cid.meta,
+          expr: expr_cid.meta,
+        }.store(env)?;
         Ok(ConstCid { anon, meta })
       }
       Const::Opaque { name, lvl, typ, expr, safe } => {
         let typ_cid = typ.clone().store(env)?;
         let expr_cid = expr.clone().store(env)?;
-        let anon = ConstAnon::Opaque(
-          lvl.len().into(),
-          typ_cid.anon,
-          expr_cid.anon,
-          *safe,
-        )
-        .store(env)?;
-        let meta = ConstMeta::Opaque(
-          name.clone(),
-          lvl.clone(),
-          typ_cid.meta,
-          expr_cid.meta,
-        )
-        .store(env)?;
+        let anon = ConstAnon::Opaque{
+          lvl: lvl.len().into(),
+          typ: typ_cid.anon,
+          expr: expr_cid.anon,
+          safe: *safe,
+        }.store(env)?;
+        let meta = ConstMeta::Opaque{
+          name: name.clone(),
+          lvl: lvl.clone(),
+          typ: typ_cid.meta,
+          expr: expr_cid.meta,
+        }.store(env)?;
         Ok(ConstCid { anon, meta })
       }
       Const::Definition { name, lvl, typ, expr, safe } => {
         let typ_cid = typ.clone().store(env)?;
         let expr_cid = expr.clone().store(env)?;
-        let anon = ConstAnon::Definition(
-          lvl.len().into(),
-          typ_cid.anon,
-          expr_cid.anon,
-          *safe,
-        )
-        .store(env)?;
-        let meta = ConstMeta::Definition(
-          name.clone(),
-          lvl.clone(),
-          typ_cid.meta,
-          expr_cid.meta,
-        )
-        .store(env)?;
+        let anon = ConstAnon::Definition{
+          lvl: lvl.len().into(),
+          typ: typ_cid.anon,
+          expr: expr_cid.anon,
+          safe: *safe,
+        }.store(env)?;
+        let meta = ConstMeta::Definition{
+          name: name.clone(),
+          lvl: lvl.clone(),
+          typ: typ_cid.meta,
+          expr: expr_cid.meta,
+        }.store(env)?;
         Ok(ConstCid { anon, meta })
       }
       Const::Inductive {
@@ -186,42 +199,42 @@ impl Const {
         nested,
       } => {
         let typ_cid = typ.clone().store(env)?;
-        let anon = ConstAnon::Inductive(
-          lvl.len().into(),
-          typ_cid.anon,
-          params.clone(),
-          indices.clone(),
-          *unit,
-          *rec,
-          *safe,
-          *refl,
-          *nested,
-        )
-        .store(env)?;
+        let anon = ConstAnon::Inductive{
+          lvl: lvl.len().into(),
+          typ: typ_cid.anon,
+          params: params.clone(),
+          indices: indices.clone(),
+          unit: *unit,
+          rec: *rec,
+          safe: *safe,
+          refl: *refl,
+          nested: *nested,
+        }.store(env)?;
         let meta =
-          ConstMeta::Inductive(name.clone(), lvl.clone(), typ_cid.meta)
-            .store(env)?;
+          ConstMeta::Inductive{
+            name: name.clone(),
+            lvl: lvl.clone(),
+            typ: typ_cid.meta
+          }.store(env)?;
         Ok(ConstCid { anon, meta })
       }
       Const::Constructor { name, lvl, ind, typ, idx, param, field, safe } => {
         let typ_cid = typ.clone().store(env)?;
-        let anon = ConstAnon::Constructor(
-          lvl.len().into(),
-          ind.anon,
-          typ_cid.anon,
-          idx.clone(),
-          param.clone(),
-          field.clone(),
-          *safe,
-        )
-        .store(env)?;
-        let meta = ConstMeta::Constructor(
-          name.clone(),
-          lvl.clone(),
-          ind.meta,
-          typ_cid.meta,
-        )
-        .store(env)?;
+        let anon = ConstAnon::Constructor{
+          lvl: lvl.len().into(),
+          ind: ind.anon,
+          typ: typ_cid.anon,
+          idx: idx.clone(),
+          param: param.clone(),
+          field: field.clone(),
+          safe: *safe,
+        }.store(env)?;
+        let meta = ConstMeta::Constructor{
+          name: name.clone(),
+          lvl: lvl.clone(),
+          ind: ind.meta,
+          typ: typ_cid.meta,
+        }.store(env)?;
         Ok(ConstCid { anon, meta })
       }
       Const::Recursor {
@@ -244,26 +257,25 @@ impl Const {
           rules_anon.push((ctor_cid.anon, fields.clone(), expr_cid.anon));
           rules_meta.push((ctor_cid.meta, expr_cid.meta));
         }
-        let anon = ConstAnon::Recursor(
-          lvl.len().into(),
-          ind.anon,
-          typ_cid.anon,
-          params.clone(),
-          indices.clone(),
-          motives.clone(),
-          minors.clone(),
-          rules_anon,
-          *k,
-          *safe,
-        )
-        .store(env)?;
+        let anon = ConstAnon::Recursor{
+          lvl: lvl.len().into(),
+          ind: ind.anon,
+          typ: typ_cid.anon,
+          params: params.clone(),
+          indices: indices.clone(),
+          motives: motives.clone(),
+          minors: minors.clone(),
+          rules: rules_anon,
+          k: *k,
+          safe: *safe,
+        }.store(env)?;
         let meta =
-          ConstMeta::Recursor(lvl.clone(), ind.meta, typ_cid.meta, rules_meta)
+          ConstMeta::Recursor{ lvl: lvl.clone(), ind: ind.meta, typ: typ_cid.meta, rules: rules_meta }
             .store(env)?;
         Ok(ConstCid { anon, meta })
       }
       Const::Quotient { kind } => {
-        let anon = ConstAnon::Quotient(*kind).store(env)?;
+        let anon = ConstAnon::Quotient{ kind: *kind }.store(env)?;
         let meta = ConstMeta::Quotient.store(env)?;
         Ok(ConstCid { anon, meta })
       }
@@ -288,18 +300,46 @@ impl Const {
 /// ConstMeta::Quotient => [7]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ConstMeta {
-  Axiom(Name, Vec<Name>, ExprMetaCid),
-  Theorem(Name, Vec<Name>, ExprMetaCid, ExprMetaCid),
-  Opaque(Name, Vec<Name>, ExprMetaCid, ExprMetaCid),
-  Definition(Name, Vec<Name>, ExprMetaCid, ExprMetaCid),
-  Inductive(Name, Vec<Name>, ExprMetaCid),
-  Constructor(Name, Vec<Name>, ConstMetaCid, ExprMetaCid),
-  Recursor(
-    Vec<Name>,
-    ConstMetaCid,
-    ExprMetaCid,
-    Vec<(ConstMetaCid, ExprMetaCid)>,
-  ),
+  Axiom {
+    name: Name,
+    lvl: Vec<Name>,
+    typ: ExprMetaCid
+  },
+  Theorem {
+    name: Name,
+    lvl: Vec<Name>,
+    typ: ExprMetaCid,
+    expr: ExprMetaCid
+  },
+  Opaque {
+    name: Name,
+    lvl: Vec<Name>,
+    typ: ExprMetaCid,
+    expr: ExprMetaCid,
+  },
+  Definition {
+    name: Name,
+    lvl: Vec<Name>,
+    typ: ExprMetaCid,
+    expr: ExprMetaCid,
+  },
+  Inductive {
+    name: Name,
+    lvl: Vec<Name>,
+    typ: ExprMetaCid,
+  },
+  Constructor {
+    name: Name,
+    lvl: Vec<Name>,
+    ind: ConstMetaCid,
+    typ: ExprMetaCid,
+  },
+  Recursor {
+    lvl: Vec<Name>,
+    ind: ConstMetaCid,
+    typ: ExprMetaCid,
+    rules: Vec<(ConstMetaCid, ExprMetaCid)>,
+  },
   Quotient,
 }
 
@@ -336,25 +376,65 @@ impl ConstMeta {
 /// ConstAnon::Quotient => [7, <kind>]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ConstAnon {
-  Axiom(Nat, ExprAnonCid),
-  Theorem(Nat, ExprAnonCid, ExprAnonCid),
-  Opaque(Nat, ExprAnonCid, ExprAnonCid, bool),
-  Definition(Nat, ExprAnonCid, ExprAnonCid, DefSafety),
-  Inductive(Nat, ExprAnonCid, Nat, Nat, bool, bool, bool, bool, bool),
-  Constructor(Nat, ConstAnonCid, ExprAnonCid, Nat, Nat, Nat, bool),
-  Recursor(
-    Nat,
-    ConstAnonCid,
-    ExprAnonCid,
-    Nat,
-    Nat,
-    Nat,
-    Nat,
-    Vec<(ConstAnonCid, Nat, ExprAnonCid)>,
-    bool,
-    bool,
-  ),
-  Quotient(QuotKind),
+  Axiom {
+    // name: Name,
+    lvl: Nat,
+    typ: ExprAnonCid
+  },
+  Theorem {
+    // name: Name,
+    lvl: Nat,
+    typ: ExprAnonCid,
+    expr: ExprAnonCid
+  },
+  Opaque {
+    // name: Name,
+    lvl: Nat,
+    typ: ExprAnonCid,
+    expr: ExprAnonCid,
+    safe: bool,
+  },
+  Definition {
+    // name: Name,
+    lvl: Nat,
+    typ: ExprAnonCid,
+    expr: ExprAnonCid,
+    safe: DefSafety,
+  },
+  Inductive {
+    lvl: Nat,
+    typ: ExprAnonCid,
+    params: Nat,
+    indices: Nat,
+    unit: bool,
+    rec: bool,
+    safe: bool,
+    refl: bool,
+    nested: bool,
+  },
+  Constructor {
+    // index: Nat,
+    lvl: Nat,
+    ind: ConstAnonCid,
+    typ: ExprAnonCid,
+    idx: Nat,
+    param: Nat,
+    field: Nat,
+    safe: bool,
+  },
+  Recursor {
+    lvl: Nat,
+    ind: ConstAnonCid,
+    typ: ExprAnonCid,
+    params: Nat,
+    indices: Nat,
+    motives: Nat,
+    minors: Nat,
+    rules: Vec<(ConstAnonCid, Nat, ExprAnonCid)>,
+    k: bool,
+    safe: bool,
+  },
+  Quotient { kind: QuotKind },
 }
 
 impl ConstAnon {

--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -37,7 +37,7 @@ pub enum DefSafety {
   Partial,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum QuotKind {
   Type,
   Ctor,

--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -30,7 +30,7 @@ use libipld::{
   codec::Codec,
 };
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum DefSafety {
   Unsafe,
   Safe,

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -44,13 +44,13 @@ pub enum Literal {
   Str(String),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LitType {
   Nat,
   Str,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BinderInfo {
   Default,
   Implicit,

--- a/yatima-rs/src/typechecker.rs
+++ b/yatima-rs/src/typechecker.rs
@@ -1,4 +1,5 @@
 pub mod check;
+pub mod from_anon;
 pub mod equality;
 pub mod evaluation;
 pub mod expression;

--- a/yatima-rs/src/typechecker/check.rs
+++ b/yatima-rs/src/typechecker/check.rs
@@ -1,3 +1,7 @@
+use crate::expression::{
+    Literal,
+    LitType,
+  };
 use crate::typechecker::{
   equality::*,
   evaluation::*,

--- a/yatima-rs/src/typechecker/evaluation.rs
+++ b/yatima-rs/src/typechecker/evaluation.rs
@@ -1,3 +1,4 @@
+use crate::constant::DefSafety;
 use crate::typechecker::{
   expression::*,
   universe::*,

--- a/yatima-rs/src/typechecker/expression.rs
+++ b/yatima-rs/src/typechecker/expression.rs
@@ -1,5 +1,6 @@
 use crate::{
   name::Name,
+  constant::QuotKind,
   nat::Nat,
   typechecker::universe::*,
 };
@@ -38,14 +39,6 @@ pub enum DefSafety {
   Unsafe,
   Safe,
   Partial,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum QuotKind {
-  Type,
-  Ctor,
-  Lift,
-  Ind,
 }
 
 /// Nameless expressions for typechecking. Such expressions must come from

--- a/yatima-rs/src/typechecker/expression.rs
+++ b/yatima-rs/src/typechecker/expression.rs
@@ -1,11 +1,18 @@
 use crate::{
   name::Name,
-  constant::QuotKind,
+  constant::{
+    DefSafety,
+    QuotKind
+  },
+  expression::{
+    BinderInfo,
+    Literal,
+    LitType,
+  },
   nat::Nat,
   typechecker::universe::*,
 };
 
-use alloc::string::String;
 use std::{
   collections::HashMap,
   rc::Rc,
@@ -13,33 +20,6 @@ use std::{
 
 pub type ExprPtr = Rc<Expr>;
 pub type ConstPtr = Rc<Const>;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Literal {
-  Nat(Nat),
-  Str(String),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum LitType {
-  Nat,
-  Str,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum BinderInfo {
-  Default,
-  Implicit,
-  StrictImplict,
-  InstImplict,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DefSafety {
-  Unsafe,
-  Safe,
-  Partial,
-}
 
 /// Nameless expressions for typechecking. Such expressions must come from
 /// ExprAnon in such a way that it preserves CID <-> Pointer correspondence.

--- a/yatima-rs/src/typechecker/expression.rs
+++ b/yatima-rs/src/typechecker/expression.rs
@@ -52,24 +52,44 @@ pub enum Expr {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Const {
   /// axiom
-  Axiom { name: Name, uvars: Nat, typ: ExprPtr },
+  Axiom {
+    // name: Name,
+    uvars: Nat,
+    typ: ExprPtr,
+    safe: bool
+  },
   /// theorem
-  Theorem { uvars: Nat, typ: ExprPtr, expr: ExprPtr },
+  Theorem {
+    uvars: Nat,
+    typ: ExprPtr,
+    expr: ExprPtr
+  },
   /// opaque
-  Opaque { name: Name, uvars: Nat, typ: ExprPtr, expr: ExprPtr, safe: bool },
+  Opaque {
+    // name: Name,
+    uvars: Nat,
+    typ: ExprPtr,
+    expr: ExprPtr,
+    safe: bool
+  },
   /// def
-  Definition { uvars: Nat, typ: ExprPtr, expr: ExprPtr, safe: DefSafety },
+  Definition {
+    uvars: Nat,
+    typ: ExprPtr,
+    expr: ExprPtr,
+    safe: DefSafety
+  },
   /// inductive type
   Inductive {
     uvars: Nat,
     typ: ExprPtr,
     params: Nat,
     indices: Nat,
-    unit: bool,
-    rec: bool,
+    ctors: Vec<(Name, Rc<Expr>)>,
+    recr: bool,
     safe: bool,
     refl: bool,
-    nested: bool,
+    nest: bool,
   },
   /// inductive constructor
   Constructor {
@@ -77,7 +97,6 @@ pub enum Const {
     uvars: Nat,
     ind: ConstPtr,
     typ: ExprPtr,
-    idx: Nat,
     param: Nat,
     field: Nat,
     safe: bool,

--- a/yatima-rs/src/typechecker/from_anon.rs
+++ b/yatima-rs/src/typechecker/from_anon.rs
@@ -1,0 +1,58 @@
+use crate::{
+  constant::ConstAnon,
+  environment::{Env, ExprAnonCid, ConstAnonCid, UnivAnonCid},
+  expression::ExprAnon,
+  typechecker::universe::Univ,
+  typechecker::expression::{Expr, Const},
+  universe::UnivAnon,
+};
+use std::rc::Rc;
+use alloc::collections::BTreeMap;
+
+pub struct ConversionEnv {
+  pub univs: BTreeMap<UnivAnonCid, Rc<Univ>>,
+  pub exprs: BTreeMap<ExprAnonCid, Rc<Expr>>,
+  pub consts: BTreeMap<ConstAnonCid, Rc<Const>>,
+}
+
+pub fn expr_from_anon(expr_cid: &ExprAnonCid, cid_env: &Env, conv_env: &mut ConversionEnv) -> Rc<Expr> {
+  match conv_env.exprs.get(expr_cid) {
+    Some(expr) => return expr.clone(),
+    None => (),
+  }
+  let expr = match cid_env.expr_anon.get(expr_cid).unwrap() {
+    ExprAnon::Var(idx) => {
+      let idx: usize = TryFrom::try_from(idx).unwrap();
+      Rc::new(Expr::Var(idx))
+    }
+    _ => todo!()
+  };
+  conv_env.exprs.insert(*expr_cid, expr.clone());
+  expr
+}
+
+pub fn const_from_anon(const_cid: &ConstAnonCid, cid_env: &Env, conv_env: &mut ConversionEnv) -> Rc<Const> {
+  match conv_env.consts.get(const_cid) {
+    Some(cnst) => return cnst.clone(),
+    None => (),
+  }
+  let cnst = match cid_env.const_anon.get(const_cid).unwrap() {
+    ConstAnon::Quotient(kind) => Rc::new(Const::Quotient{ kind: *kind }),
+    _ => todo!()
+  };
+  conv_env.consts.insert(*const_cid, cnst.clone());
+  cnst
+}
+
+pub fn univ_from_anon(univ_cid: &UnivAnonCid, cid_env: &Env, conv_env: &mut ConversionEnv) -> Rc<Univ> {
+  match conv_env.univs.get(univ_cid) {
+    Some(expr) => return expr.clone(),
+    None => (),
+  }
+  let univ = match cid_env.univ_anon.get(univ_cid).unwrap() {
+    UnivAnon::Zero => Rc::new(Univ::Zero),
+    _ => todo!()
+  };
+  conv_env.univs.insert(*univ_cid, univ.clone());
+  univ
+}

--- a/yatima-rs/src/typechecker/from_anon.rs
+++ b/yatima-rs/src/typechecker/from_anon.rs
@@ -25,7 +25,45 @@ pub fn expr_from_anon(expr_cid: &ExprAnonCid, cid_env: &Env, conv_env: &mut Conv
       let idx: usize = TryFrom::try_from(idx).unwrap();
       Rc::new(Expr::Var(idx))
     }
-    _ => todo!()
+    ExprAnon::Sort(univ_cid) => {
+      let lvl = univ_from_anon(univ_cid, cid_env, conv_env);
+      Rc::new(Expr::Sort(lvl))
+    },
+    ExprAnon::Const(const_cid, univ_cids) => {
+      let cnst = const_from_anon(const_cid, cid_env, conv_env);
+      let lvls = univ_cids
+        .iter()
+        .map(|univ_cid| univ_from_anon(univ_cid, cid_env, conv_env))
+        .collect();
+      Rc::new(Expr::Const(cnst, lvls))
+    },
+    ExprAnon::App(fun_cid, arg_cid) => {
+      let fun = expr_from_anon(fun_cid, cid_env, conv_env);
+      let arg = expr_from_anon(arg_cid, cid_env, conv_env);
+      Rc::new(Expr::App(fun, arg))
+    },
+    ExprAnon::Lam(binfo, dom_cid, bod_cid) => {
+      let dom = expr_from_anon(dom_cid, cid_env, conv_env);
+      let bod = expr_from_anon(bod_cid, cid_env, conv_env);
+      Rc::new(Expr::Lam(*binfo, dom, bod))
+    },
+    ExprAnon::Pi(binfo, dom_cid, cod_cid) => {
+      let dom = expr_from_anon(dom_cid, cid_env, conv_env);
+      let cod = expr_from_anon(cod_cid, cid_env, conv_env);
+      Rc::new(Expr::Pi(*binfo, dom, cod))
+    },
+    ExprAnon::Let(typ_cid, exp_cid, bod_cid) => {
+      let typ = expr_from_anon(typ_cid, cid_env, conv_env);
+      let exp = expr_from_anon(exp_cid, cid_env, conv_env);
+      let bod = expr_from_anon(bod_cid, cid_env, conv_env);
+      Rc::new(Expr::Let(typ, exp, bod))
+    },
+    ExprAnon::Lit(lit) => Rc::new(Expr::Lit(lit.clone())),
+    ExprAnon::Lty(lty) => Rc::new(Expr::Lty(*lty)),
+    ExprAnon::Fix(bod_cid) => {
+      let bod = expr_from_anon(bod_cid, cid_env, conv_env);
+      Rc::new(Expr::Fix(bod))
+    },
   };
   conv_env.exprs.insert(*expr_cid, expr.clone());
   expr
@@ -38,7 +76,13 @@ pub fn const_from_anon(const_cid: &ConstAnonCid, cid_env: &Env, conv_env: &mut C
   }
   let cnst = match cid_env.const_anon.get(const_cid).unwrap() {
     ConstAnon::Quotient(kind) => Rc::new(Const::Quotient{ kind: *kind }),
-    _ => todo!()
+    ConstAnon::Axiom(..) => todo!(),
+    ConstAnon::Theorem(..) => todo!(),
+    ConstAnon::Opaque(..) => todo!(),
+    ConstAnon::Definition(..) => todo!(),
+    ConstAnon::Inductive(..) => todo!(),
+    ConstAnon::Constructor(..) => todo!(),
+    ConstAnon::Recursor(..) => todo!(),
   };
   conv_env.consts.insert(*const_cid, cnst.clone());
   cnst
@@ -51,7 +95,10 @@ pub fn univ_from_anon(univ_cid: &UnivAnonCid, cid_env: &Env, conv_env: &mut Conv
   }
   let univ = match cid_env.univ_anon.get(univ_cid).unwrap() {
     UnivAnon::Zero => Rc::new(Univ::Zero),
-    _ => todo!()
+    UnivAnon::Succ(..) => todo!(),
+    UnivAnon::Max(..) => todo!(),
+    UnivAnon::IMax(..) => todo!(),
+    UnivAnon::Param(..) => todo!(),
   };
   conv_env.univs.insert(*univ_cid, univ.clone());
   univ

--- a/yatima-rs/src/typechecker/from_anon.rs
+++ b/yatima-rs/src/typechecker/from_anon.rs
@@ -22,7 +22,7 @@ pub fn expr_from_anon(expr_cid: &ExprAnonCid, cid_env: &Env, conv_env: &mut Conv
   }
   let expr = match cid_env.expr_anon.get(expr_cid).unwrap() {
     ExprAnon::Var(idx) => {
-      let idx: usize = TryFrom::try_from(idx).unwrap();
+      let idx = TryFrom::try_from(idx).unwrap();
       Rc::new(Expr::Var(idx))
     }
     ExprAnon::Sort(univ_cid) => {
@@ -95,10 +95,24 @@ pub fn univ_from_anon(univ_cid: &UnivAnonCid, cid_env: &Env, conv_env: &mut Conv
   }
   let univ = match cid_env.univ_anon.get(univ_cid).unwrap() {
     UnivAnon::Zero => Rc::new(Univ::Zero),
-    UnivAnon::Succ(..) => todo!(),
-    UnivAnon::Max(..) => todo!(),
-    UnivAnon::IMax(..) => todo!(),
-    UnivAnon::Param(..) => todo!(),
+    UnivAnon::Succ(lvl_cid) => {
+      let lvl = univ_from_anon(lvl_cid, cid_env, conv_env);
+      Rc::new(Univ::Succ(lvl))
+    },
+    UnivAnon::Max(l_lvl_cid, r_lvl_cid) => {
+      let l_lvl = univ_from_anon(l_lvl_cid, cid_env, conv_env);
+      let r_lvl = univ_from_anon(r_lvl_cid, cid_env, conv_env);
+      Rc::new(Univ::Max(l_lvl, r_lvl))
+    },
+    UnivAnon::IMax(l_lvl_cid, r_lvl_cid) => {
+      let l_lvl = univ_from_anon(l_lvl_cid, cid_env, conv_env);
+      let r_lvl = univ_from_anon(r_lvl_cid, cid_env, conv_env);
+      Rc::new(Univ::IMax(l_lvl, r_lvl))
+    },
+    UnivAnon::Param(idx) => {
+      let idx = TryFrom::try_from(idx).unwrap();
+      Rc::new(Univ::Var(idx))
+    },
   };
   conv_env.univs.insert(*univ_cid, univ.clone());
   univ

--- a/yatima-rs/src/typechecker/from_anon.rs
+++ b/yatima-rs/src/typechecker/from_anon.rs
@@ -75,14 +75,14 @@ pub fn const_from_anon(const_cid: &ConstAnonCid, cid_env: &Env, conv_env: &mut C
     None => (),
   }
   let cnst = match cid_env.const_anon.get(const_cid).unwrap() {
-    ConstAnon::Quotient(kind) => Rc::new(Const::Quotient{ kind: *kind }),
-    ConstAnon::Axiom(..) => todo!(),
-    ConstAnon::Theorem(..) => todo!(),
-    ConstAnon::Opaque(..) => todo!(),
-    ConstAnon::Definition(..) => todo!(),
-    ConstAnon::Inductive(..) => todo!(),
-    ConstAnon::Constructor(..) => todo!(),
-    ConstAnon::Recursor(..) => todo!(),
+    ConstAnon::Quotient { kind } => Rc::new(Const::Quotient{ kind: *kind }),
+    ConstAnon::Axiom { .. } => todo!(),
+    ConstAnon::Theorem { .. } => todo!(),
+    ConstAnon::Opaque { .. } => todo!(),
+    ConstAnon::Definition { .. } => todo!(),
+    ConstAnon::Inductive { .. } => todo!(),
+    ConstAnon::Constructor { .. } => todo!(),
+    ConstAnon::Recursor { .. } => todo!(),
   };
   conv_env.consts.insert(*const_cid, cnst.clone());
   cnst

--- a/yatima-rs/src/typechecker/value.rs
+++ b/yatima-rs/src/typechecker/value.rs
@@ -1,3 +1,8 @@
+use crate::expression::{
+    BinderInfo,
+    Literal,
+    LitType,
+  };
 use crate::typechecker::{
   expression::*,
   universe::*,


### PR DESCRIPTION
This PR implements translations from anonymous IPLD versions of `Expr`, `Const` and `Univ` into the typechecker versions. The basic difference between each version is that IPLD uses CID to connect nodes, requiring hashmap or btreemap lookup, while the typechecker versions contain actual pointers; thus, a much faster access to children nodes. The translation is done in such a way that you have a 1-1 correspondence between CIDs and pointers, which means that pointer equality is equivalent to CID equality. This allows us to not need CIDs at all inside the typechecker.

Furthermore, I've made a couple of changes to `constant.rs`. `ConstAnon` and `ConstMeta` now have named arguments, like `Const`. The second change I've made is that `ConstAnon::Constructor` now takes a `name` argument instead of an index argument, so I've removed `name` from `ConstMeta::Constructor`. It seems that this is equivalent to having name in Meta and an index (corresponding to the position of the constructor in its inductive constructor list) in Anon, though a bit simpler, I believe. But this is up to debate.