### PR TITLE
Problem: no way to encode projections

### DIFF
--- a/Yatima/Expr.lean
+++ b/Yatima/Expr.lean
@@ -31,6 +31,7 @@ inductive Expr
   | lit   : Literal → Expr
   | lty   : LitType → Expr
   | fix   : Name → Expr → Expr
+  | proj  : Nat → Expr → Expr
   deriving BEq, Inhabited
 
 inductive ExprAnon
@@ -44,6 +45,7 @@ inductive ExprAnon
   | lit   : Literal → ExprAnon
   | lty   : LitType → ExprAnon
   | fix   : ExprAnonCid → ExprAnon
+  | proj  : Nat → ExprAnonCid → ExprAnon
   deriving BEq, Inhabited
 
 inductive ExprMeta
@@ -57,6 +59,7 @@ inductive ExprMeta
   | lit   : ExprMeta
   | lty   : ExprMeta
   | fix   : Name → ExprMetaCid → ExprMeta
+  | proj  : Nat → ExprMetaCid → ExprMeta
   deriving BEq, Inhabited
 
 end Yatima

--- a/Yatima/FromLean.lean
+++ b/Yatima/FromLean.lean
@@ -110,6 +110,9 @@ mutual
     | .fix nam exp => do
       let expCid ← exprToCid exp
       return (.fix expCid.anon, .fix nam expCid.meta)
+    | .proj idx exp => do
+      let expCid ← exprToCid exp
+      return (.proj idx expCid.anon, .proj idx expCid.meta)
 
   def exprToCid (e : Expr) : EnvM ExprCid := do
     let (exprAnon, exprMeta) ← separateExpr e
@@ -217,7 +220,9 @@ mutual
       return .letE nam typ exp bod
     | .lit lit _ => return .lit lit
     | .mdata _ e _ => toYatimaExpr levelParams e
-    | .proj .. => sorry
+    | .proj _ idx exp _ => do
+      let exp ← toYatimaExpr levelParams exp
+      return .proj idx exp
     | .fvar .. => throw "Free variable found"
     | .mvar .. => throw "Metavariable found"
 

--- a/Yatima/ToIpld.lean
+++ b/Yatima/ToIpld.lean
@@ -92,6 +92,7 @@ def exprAnonToIpld : ExprAnon → Ipld
   | .lit l      => .array #[.number EXPRANON, .number 7, l]
   | .lty l      => .array #[.number EXPRANON, .number 8, l]
   | .fix b      => .array #[.number EXPRANON, .number 9, b]
+  | .proj n e   => .array #[.number EXPRANON, .number 10, n, e]
 
 def exprMetaToIpld : ExprMeta → Ipld
   | .var n        => .array #[.number EXPRMETA, .number 0, n]
@@ -104,6 +105,7 @@ def exprMetaToIpld : ExprMeta → Ipld
   | .lit          => .array #[.number EXPRMETA, .number 7]
   | .lty          => .array #[.number EXPRMETA, .number 8]
   | .fix n b      => .array #[.number EXPRMETA, .number 9, n, b]
+  | .proj n e     => .array #[.number EXPRANON, .number 10, n, e]
 
 def constAnonToIpld : ConstAnon → Ipld
   | .axiom ⟨l, t, s⟩         => .array #[.number CONSTANON, .number 0, l, t, s]

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -15,6 +15,7 @@ use crate::{
   name::Name,
   nat::Nat,
 };
+
 use serde::{
   Deserialize,
   Serialize,
@@ -84,6 +85,8 @@ pub enum Expr {
   Lty(LitType),
   /// Fixpoint recursion, μ x. x
   Fix(Name, Box<Expr>),
+  /// Projections 
+  Proj(Nat, Box<Expr>),
 }
 
 impl Expr {
@@ -163,6 +166,12 @@ impl Expr {
         let meta = ExprMeta::Fix(name.clone(), x_cid.meta).store(env)?;
         Ok(ExprCid { anon, meta })
       }
+      Expr::Proj(idx, exp) => {
+        let exp_cid = exp.cid(env)?;
+        let anon = ExprAnon::Proj(idx.clone(), exp_cid.anon).store(env)?;
+        let meta = ExprMeta::Proj(idx.clone(), exp_cid.meta).store(env)?;
+        Ok(ExprCid { anon, meta })
+      }
     }
   }
 
@@ -227,6 +236,7 @@ impl Expr {
 /// ExprMeta::Lit => [7]
 /// ExprMeta::Lty => [8]
 /// ExprMeta::Fix => [9, <name>, <body>]
+/// ExprMeta::Proj => [10, <expr>]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ExprMeta {
   Var(Name),
@@ -239,6 +249,7 @@ pub enum ExprMeta {
   Lit,
   Lty,
   Fix(Name, ExprMetaCid),
+  Proj(Nat, ExprMetaCid),
 }
 
 impl ExprMeta {
@@ -267,6 +278,7 @@ impl ExprMeta {
 /// ExprAnon::Lit => [7, <lit>]
 /// ExprAnon::Lty => [8, <lty>]
 /// ExprAnon::Fix => [9, <body>]
+/// ExprAnon::Proj => [10, <expr>]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ExprAnon {
   Var(Nat),
@@ -279,6 +291,7 @@ pub enum ExprAnon {
   Lit(Literal),
   Lty(LitType),
   Fix(ExprAnonCid),
+  Proj(Nat, ExprAnonCid),
 }
 
 impl ExprAnon {

--- a/yatima-rs/src/typechecker/check.rs
+++ b/yatima-rs/src/typechecker/check.rs
@@ -113,5 +113,6 @@ pub fn infer(
       Ok(Value::Sort(one))
     }
     Expr::Fix(..) => Err(CheckError::CannotInferFix),
+    _ => todo!() // Projections
   }
 }

--- a/yatima-rs/src/typechecker/evaluation.rs
+++ b/yatima-rs/src/typechecker/evaluation.rs
@@ -89,7 +89,8 @@ pub fn eval(expr: ExprPtr, mut env: Env) -> Value {
       let itself = suspend(expr, env.clone());
       env.exprs.push_front(itself);
       eval(body, env)
-    }
+    },
+    _ => todo!() // Projections
   }
 }
 

--- a/yatima-rs/src/typechecker/expression.rs
+++ b/yatima-rs/src/typechecker/expression.rs
@@ -45,6 +45,8 @@ pub enum Expr {
   Lty(LitType),
   /// Fixpoint recursion, μ x. x
   Fix(ExprPtr),
+  /// Projections
+  Proj(Index, ExprPtr),
 }
 
 /// Constants for typechecking. They must also come from their anon

--- a/yatima-rs/src/typechecker/from_anon.rs
+++ b/yatima-rs/src/typechecker/from_anon.rs
@@ -67,6 +67,10 @@ pub fn expr_from_anon(expr_cid: &ExprAnonCid, cid_env: &Env, conv_env: &mut Conv
       let bod = expr_from_anon(bod_cid, cid_env, conv_env);
       Rc::new(Expr::Fix(bod))
     },
+    ExprAnon::Proj(idx, exp_cid) => {
+      let exp = expr_from_anon(exp_cid, cid_env, conv_env);
+      Rc::new(Expr::Fix(exp))
+    },
   };
   conv_env.exprs.insert(*expr_cid, expr.clone());
   expr

--- a/yatima-rs/src/typechecker/from_anon.rs
+++ b/yatima-rs/src/typechecker/from_anon.rs
@@ -68,8 +68,9 @@ pub fn expr_from_anon(expr_cid: &ExprAnonCid, cid_env: &Env, conv_env: &mut Conv
       Rc::new(Expr::Fix(bod))
     },
     ExprAnon::Proj(idx, exp_cid) => {
+      let idx = TryFrom::try_from(idx).unwrap();
       let exp = expr_from_anon(exp_cid, cid_env, conv_env);
-      Rc::new(Expr::Fix(exp))
+      Rc::new(Expr::Proj(idx, exp))
     },
   };
   conv_env.exprs.insert(*expr_cid, expr.clone());


### PR DESCRIPTION
Problem: no way to encode projections

Solution:
* Add a constructor per Expr type (Expr, ExprAnon and ExprMeta)
* Make sure we can store proj exprs with IPLD
   * Use Coe instance declared before to constuct Ipld.array with Nat n verbatim
* Make projections separable into Anon and Meta
   * First convert raw Yatima.Expr into Cid-aware, wrapped in EnvM with exprToCid
   * Cid-aware expressions contain both Anon and Meta CID exprs, so we can construct the tuple,
     indexed with the the relevant attribute offset index.
* Patch away `sorry` in a recursive toYatimaExpr that converts Lean exprs to Yatima exprs
   * Construct Yatima.Expr using the .proj constructor mentioned earlier.
   * We disregard name and data fields of Lean.Expr constructor, because those aren't
     needed for typechecking. This is a design choice that we'll revisit later and may add
     names if it shall be problematic for typechecking.

Side-note:
* We don't save anything into EnvM (as we do in toYatimaUniv) because a
  constructed value of type Expr has all the data needed, whereas
  a Univ value has references to UnivCid's, which means that as we construct
  it, we need to save the referred Univ values into EnvM

Closes #37 