### PR TITLE
Pretty-printing and property-tests

### DIFF
--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -389,11 +389,13 @@ impl Const {
         let (bds, sort) = get_binders(typ, Some(params + indices));
         let bds: Vec<String> = bds.iter().map(|((n, bi), e)| with_binders(format!("{n} : {}", e.pretty(env, ind)), bi)).collect();
         let ctors_str = print_constructors(ind, env, ctors)?;
-        Some(format!("inductive {} {{{}}} {} : {} -> {} where\n{}",
+        let sort_sep = if *indices > 0 { " -> " } else { "" };
+        Some(format!("inductive {} {{{}}} {} : {}{}{} where\n{}",
                       name,
                       pretty_lvls(lvl),
                       bds[0..*params].join(" "), // print params
                       bds[*params..].join(" "), // print indices
+                      sort_sep,
                       sort.pretty(env, ind),
                       ctors_str)) // print ctors
       }
@@ -710,9 +712,9 @@ pub mod tests {
           let univs = (&univs[..num_univs]).to_vec();
           let univ_ctx = Vector::from(univs.clone());
 
-          let num_params = usize::arbitrary(g) % 2;
-          let num_inds = usize::arbitrary(g) % 2;
-          let num_ctors = usize::arbitrary(g) % 2;
+          let num_params = usize::arbitrary(g) % 10;
+          let num_inds = usize::arbitrary(g) % 10;
+          let num_ctors = usize::arbitrary(g) % 10;
 
           let typ = arbitrary_pi(g, num_params + num_inds, &Vector::new(), &univ_ctx, &dummy_global_ctx());
 
@@ -725,9 +727,9 @@ pub mod tests {
           }
 
           let mut ctors = Vec::new();
-          for _ in [0..num_ctors] {
+          for _ in 0..num_ctors {
             let ctor_name = arbitrary_ascii_name(g, 5);
-            let ctor_depth = usize::arbitrary(g) % 2;
+            let ctor_depth = usize::arbitrary(g) % 10;
             let ctor_type = arbitrary_pi(g, ctor_depth, &ctor_bind_ctx, &univ_ctx, &dummy_global_ctx());
             env.extend(ctor_type.env);
             ctors.push((ctor_name, ctor_type.expr));

--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -316,7 +316,7 @@ impl Const {
       let res = 
         ctors.into_iter()
              .map(|(name, expr)| 
-              format!("| {} {}", name, expr.parse_binders(ind, Nat::from(u32::MAX)).1))
+              format!("| {} {}", name, expr.parse_binders(env, ind, Nat::from(u32::MAX)).1))
              .collect::<Vec<String>>()
              .join(" ");
       Some(res)
@@ -331,7 +331,7 @@ impl Const {
                       safe, 
                       name, 
                       pretty_lvls(lvl), 
-                      typ.pretty(ind)))
+                      typ.pretty(env, ind)))
       }
       // Theorem: theorem <name> {lvl*} : <typ> := <expr>
       Const::Theorem { name, lvl, typ, expr } => {
@@ -340,8 +340,8 @@ impl Const {
         Some(format!("theorem {} {{{}}} : {} := {}", 
                       name, 
                       pretty_lvls(lvl), 
-                      typ.pretty(ind),
-                      expr.pretty(ind)))
+                      typ.pretty(env, ind),
+                      expr.pretty(env, ind)))
       }
       // Opaque: unsafe? opaque rec? <name> {lvl*} : <typ> := <expr>
       Const::Opaque { name, lvl, typ, expr, safe } => {
@@ -364,7 +364,7 @@ impl Const {
         let typ = env.expr_cache.get(&typ)?; 
         // here `<typ>` looks like `<params> -> <indices> -> <name>`
         // we need to unwrap the `<params>`
-        let (params, remaining_typ) = typ.parse_binders(ind, params);
+        let (params, remaining_typ) = typ.parse_binders(env, ind, params);
         let ctors_str = print_constructors(ind, env, ctors)?;
         Some(format!("{} inductive {} {} {{{}}} ({}) : {} where {}",
                       safe, 
@@ -372,7 +372,7 @@ impl Const {
                       name,
                       pretty_lvls(lvl),
                       params, // print params
-                      remaining_typ.pretty(ind),
+                      remaining_typ.pretty(env, ind),
                       ctors_str)) // print ctors
       }
       Const::Constructor { name, lvl, ind, typ, param, field, safe } => {

--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -508,7 +508,12 @@ impl Const {
       },
       Const::Inductive { name, lvl, typ, params, indices, ctors, recr, safe, refl, nest } => {
         let typ = env.expr_cache.get(&typ).unwrap();
-        typ.get_internal_refs()
+        let mut refs = typ.get_internal_refs();
+        for (_, ctorcid) in ctors {
+          let ctor = env.expr_cache.get(&ctorcid).unwrap();
+          refs.extend(ctor.get_internal_refs());
+        }
+        refs
       },
       Const::Constructor { name, lvl, ind, typ, param, field, safe } => {
         let typ = env.expr_cache.get(&typ).unwrap();

--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -309,7 +309,7 @@ impl Const {
     Ok(cid)
   }
 
-  pub fn pretty(&self, ind: bool, env: &Env) -> Option<String> {
+  pub fn pretty(&self, env: &Env, ind: bool) -> Option<String> {
     fn pretty_lvls(lvl: &Vec<Name>) -> String {
       lvl.iter()
          .map(|level| level.to_string())
@@ -389,9 +389,7 @@ impl Const {
         let (bds, sort) = get_binders(typ, Some(params + indices));
         let bds: Vec<String> = bds.iter().map(|((n, bi), e)| with_binders(format!("{n} : {}", e.pretty(env, ind)), bi)).collect();
         let ctors_str = print_constructors(ind, env, ctors)?;
-        Some(format!("{} inductive {} {} {{{}}} {} : {} -> {} where\n{}",
-                      safe, 
-                      recr,
+        Some(format!("inductive {} {{{}}} {} : {} -> {} where\n{}",
                       name,
                       pretty_lvls(lvl),
                       bds[0..*params].join(" "), // print params
@@ -652,11 +650,7 @@ pub mod tests {
       UnivCtx,
   };
 
-  use crate::universe::Univ;
-  use crate::expression::{
-    ExprEnv,
-    tests::{arbitrary_exprenv, dummy_global_ctx}
-  };
+  use crate::expression::tests::{ExprEnv, arbitrary_exprenv, dummy_global_ctx};
 
   use im::{
     OrdMap,
@@ -675,9 +669,9 @@ pub mod tests {
   use crate::universe::tests::dummy_univ_ctx;
 
   #[derive(Clone, Debug, PartialEq)]
-  struct ConstEnv {
-    cnst: Const,
-    env: Env
+  pub struct ConstEnv {
+    pub cnst: Const,
+    pub env: Env
   }
 
   fn arbitrary_pi(g: &mut Gen, depth: usize, bind_ctx: &BindCtx, univ_ctx: &UnivCtx, global_ctx: &GlobalCtx) -> ExprEnv {
@@ -760,7 +754,7 @@ pub mod tests {
               //refl: bool::arbitrary(g),
               //nest: bool::arbitrary(g),
               recr: false,
-              safe: false,
+              safe: true,
               refl: false,
               nest: false,
             },

--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -710,9 +710,9 @@ pub mod tests {
           let univs = (&univs[..num_univs]).to_vec();
           let univ_ctx = Vector::from(univs.clone());
 
-          let num_params = usize::arbitrary(g) % 10;
-          let num_inds = usize::arbitrary(g) % 10;
-          let num_ctors = usize::arbitrary(g) % 10;
+          let num_params = usize::arbitrary(g) % 2;
+          let num_inds = usize::arbitrary(g) % 2;
+          let num_ctors = usize::arbitrary(g) % 2;
 
           let typ = arbitrary_pi(g, num_params + num_inds, &Vector::new(), &univ_ctx, &dummy_global_ctx());
 
@@ -727,7 +727,7 @@ pub mod tests {
           let mut ctors = Vec::new();
           for _ in [0..num_ctors] {
             let ctor_name = arbitrary_ascii_name(g, 5);
-            let ctor_depth = usize::arbitrary(g) % 10;
+            let ctor_depth = usize::arbitrary(g) % 2;
             let ctor_type = arbitrary_pi(g, ctor_depth, &ctor_bind_ctx, &univ_ctx, &dummy_global_ctx());
             env.extend(ctor_type.env);
             ctors.push((ctor_name, ctor_type.expr));

--- a/yatima-rs/src/constant.rs
+++ b/yatima-rs/src/constant.rs
@@ -897,9 +897,6 @@ pub mod tests {
 
         let mut env = typ.env;
 
-        let exprenv = arbitrary_exprenv(g, &Vector::new(), &univ_ctx, &global_ctx);
-        env.extend(exprenv.env);
-
         ConstEnv {
           cnst: Const::Axiom {
             name: name.clone(),

--- a/yatima-rs/src/environment.rs
+++ b/yatima-rs/src/environment.rs
@@ -319,7 +319,7 @@ impl Env {
     let cids = self.topo_sort();
     let res = cids.into_iter().map(|cid| {
       let decl = self.const_cache.get(&cid).unwrap();
-      let pretty = decl.pretty(ind, self);
+      let pretty = decl.pretty(self, ind);
       pretty
     }).collect::<Option<Vec<_>>>()?.join("\n\n");
     Some(res)

--- a/yatima-rs/src/environment.rs
+++ b/yatima-rs/src/environment.rs
@@ -305,7 +305,7 @@ impl Env {
       for n in const_dag.get(&curr).unwrap().neighbours.clone() {
         const_dag.get_mut(&n).unwrap().in_degree -= 1;
         if const_dag.get(&n).unwrap().in_degree == 0 {
-          res.push_back(n);
+          s.push_back(n);
         }
       }
     }
@@ -319,7 +319,7 @@ impl Env {
       let decl = self.const_cache.get(&cid).unwrap();
       let pretty = decl.pretty(self, ind);
       pretty
-    }).collect::<Option<Vec<_>>>()?.join("\n\n");
+    }).rev().collect::<Option<Vec<_>>>()?.join("\n\n");
     Some(res)
   } 
 }
@@ -342,7 +342,7 @@ pub mod tests {
   
   impl Arbitrary for Env {
     fn arbitrary(g: &mut Gen) -> Env {
-      let env_size = 1;
+      let env_size = usize::arbitrary(g) % 10 + 1;
 
       let mut global_ctx = OrdMap::new();
       let mut env = Env::new();

--- a/yatima-rs/src/environment.rs
+++ b/yatima-rs/src/environment.rs
@@ -326,15 +326,6 @@ impl Env {
 
 #[cfg(test)]
 pub mod tests {
-  use crate::test::frequency;
-  use crate::parse::utils::{
-      BindCtx,
-      GlobalCtx,
-      UnivCtx,
-  };
-
-  use crate::expression::tests::{ExprEnv, arbitrary_exprenv, dummy_global_ctx};
-
   use crate::name::tests::arbitrary_ascii_name;
 
   use crate::constant::tests::arbitrary_constenv;
@@ -351,7 +342,7 @@ pub mod tests {
   
   impl Arbitrary for Env {
     fn arbitrary(g: &mut Gen) -> Env {
-      let env_size = usize::arbitrary(g) % 100;
+      let env_size = 1;
 
       let mut global_ctx = OrdMap::new();
       let mut env = Env::new();

--- a/yatima-rs/src/environment.rs
+++ b/yatima-rs/src/environment.rs
@@ -227,4 +227,12 @@ impl Env {
   pub fn insert_const_cache(&mut self, k: ConstCid, v: Const) {
     self.const_cache.insert(k, v);
   }
+
+  /// Top level printer that will produce all the decls in an enviorment 
+  pub fn pretty(&self, ind: bool) -> String {
+    // loop over all decls and print them out
+    // actually wait a minute...?
+    // how do we print stuff out in the correct order? bruh
+    "".to_string()
+  } 
 }

--- a/yatima-rs/src/environment.rs
+++ b/yatima-rs/src/environment.rs
@@ -176,6 +176,18 @@ impl Env {
     }
   }
 
+  pub fn extend(&mut self, other: Self){
+    self.const_cache.extend(other.const_cache);
+    self.expr_cache.extend(other.expr_cache);
+    self.univ_cache.extend(other.univ_cache);
+    self.const_meta.extend(other.const_meta);
+    self.expr_meta.extend(other.expr_meta);
+    self.univ_meta.extend(other.univ_meta);
+    self.const_anon.extend(other.const_anon);
+    self.expr_anon.extend(other.expr_anon);
+    self.univ_anon.extend(other.univ_anon);
+  }
+
   pub fn insert_univ_anon(&mut self, k: UnivAnonCid, v: UnivAnon) {
     self.univ_anon.insert(k, v);
   }
@@ -186,6 +198,10 @@ impl Env {
 
   pub fn insert_univ_cache(&mut self, k: UnivCid, v: Univ) {
     self.univ_cache.insert(k, v);
+  }
+
+  pub fn get_univ_cache(&self, k: &UnivCid) -> Option<&Univ> {
+    self.univ_cache.get(k)
   }
 
   pub fn insert_expr_anon(&mut self, k: ExprAnonCid, v: ExprAnon) {

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -13,7 +13,7 @@ use crate::{
     UnivMetaCid,
   },
   name::Name,
-  nat::Nat,
+  nat::Nat, typechecker::check::infer,
 };
 use serde::{
   Deserialize,
@@ -397,6 +397,7 @@ impl Expr {
       Expr::Fix(_, expr) => {
         format!("{}", expr.pretty(env, ind)) 
       },
+      _ => todo!() // Projections
     }
   }
 }

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -288,7 +288,7 @@ impl Expr {
   pub fn pretty(&self, env: &Env, ind: bool) -> String {
     
     fn is_atom(expr: &Expr) -> bool {
-      matches!(expr, Expr::Const(..) | Expr::Var(..) | Expr::Sort(..) | Expr::Lit(..) | Expr::Lty(..))
+      matches!(expr, Expr::Const(..) | Expr::Var(..) | Expr::Lit(..) | Expr::Lty(..))
     }
 
     // Basic logic around parantheses, makes sure we don't do atoms.
@@ -335,19 +335,11 @@ impl Expr {
     // Handle nested applications
     fn apps(env: &Env, ind: bool, fun: &Expr, arg: &Expr) -> String {
       match (fun, arg) {
-        (Expr::App(fun, arg1), Expr::App(f, arg2)) => {
-          // Not sure why we need this case, but this was in lang-alpha
-          format!(
-            "{} ({})",
-            apps(env, ind, fun, arg1),
-            apps(env, ind, f, arg2)
-          )
+        (fun, Expr::App(fun2, arg)) => {
+          format!("{} ({})", parens(env, ind, fun), apps(env, ind, fun2, arg))
         }
         (Expr::App(fun, arg1), arg2) => {
           format!("{} {}", apps(env, ind, fun, arg1), parens(env, ind, arg2))
-        }
-        (fun, Expr::App(fun2, arg)) => {
-          format!("{} ({})", parens(env, ind, fun), apps(env, ind, fun2, arg))
         }
         (fun, arg) => {
           format!("{} {}", parens(env, ind, fun), parens(env, ind, arg))

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -42,6 +42,8 @@ use libipld::{
   codec::Codec,
 };
 
+use crate::parse::utils::with_binders;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Literal {
   Nat(Nat),
@@ -261,16 +263,6 @@ impl Expr {
       }
       else {
         format!("({})", expr.pretty(env, ind))
-      }
-    }
-
-    // This feels slightly hacky
-    fn with_binders(var: String, bi: &BinderInfo) -> String {
-      match bi {
-        BinderInfo::Default => format!("({})", var),
-        BinderInfo::Implicit => format!("{{{}}}", var),
-        BinderInfo::InstImplicit => format!("[{}]", var),
-        BinderInfo::StrictImplicit => format!("{{{{{}}}}}", var),
       }
     }
 

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -505,9 +505,9 @@ impl ExprAnon {
 
   impl Arbitrary for Expr {
     fn arbitrary(g: &mut Gen) -> Self {
-      let rec_freq = g.size().saturating_sub(10);
+      let rec_freq = g.size().saturating_sub(50);
       let input: Vec<(usize, Box<dyn Fn(&mut Gen) -> Expr>)> = vec![
-        (1, Box::new(|_| Expr::Var(Name::from("_temp"), 0u8.into()))),
+        (100, Box::new(|_| Expr::Var(Name::from("_temp"), 0u8.into()))),
         (rec_freq, Box::new(|g| {
           Expr::App(
             Box::new(Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1)))),

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -335,9 +335,6 @@ impl Expr {
     // Handle nested applications
     fn apps(env: &Env, ind: bool, fun: &Expr, arg: &Expr) -> String {
       match (fun, arg) {
-        (fun, Expr::App(fun2, arg)) => {
-          format!("{} ({})", parens(env, ind, fun), apps(env, ind, fun2, arg))
-        }
         (Expr::App(fun, arg1), arg2) => {
           format!("{} {}", apps(env, ind, fun, arg1), parens(env, ind, arg2))
         }

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -113,12 +113,6 @@ pub enum Expr {
   Proj(Nat, Box<Expr>),
 }
 
-#[derive(PartialEq, Clone, Debug)]
-pub struct ExprEnv {
-  pub expr: Expr,
-  pub env: Env,
-}
-
 impl Expr {
   pub fn cid(&self, env: &mut Env) -> Result<ExprCid, EnvError> {
     match self {
@@ -497,6 +491,8 @@ impl ExprAnon {
     Gen,
   };
 
+  use crate::name::tests::arbitrary_ascii_name;
+
   use super::*;
 
   pub fn dummy_const_cid(ind: u8) -> ConstCid {
@@ -518,7 +514,11 @@ impl ExprAnon {
     Vector::from(vec![Name::from("w"), Name::from("v"), Name::from("u")])
   }
 
-  use crate::name::tests::arbitrary_ascii_name;
+  #[derive(PartialEq, Clone, Debug)]
+  pub struct ExprEnv {
+    pub expr: Expr,
+    pub env: Env,
+  }
 
   // TODO can I #[derive(Arbitrary)]?
   impl Arbitrary for BinderInfo {

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -566,13 +566,13 @@ impl ExprAnon {
   }
 
   fn arbitrary_sort(univ_ctx: &UnivCtx) -> ExprEnv {
-      let mut env = Env::new();
-      let univ: Univ = arbitrary_univ(&mut Gen::new(50), univ_ctx);
-      let univ_cid = univ.store(&mut env).unwrap();
-      ExprEnv {
-        expr: Expr::Sort(univ_cid),
-        env
-      }
+    let mut env = Env::new();
+    let univ: Univ = arbitrary_univ(&mut Gen::new(50), univ_ctx);
+    let univ_cid = univ.store(&mut env).unwrap();
+    ExprEnv {
+      expr: Expr::Sort(univ_cid),
+      env
+    }
   }
 
   pub fn arbitrary_exprenv(g: &mut Gen, bind_ctx: &BindCtx, univ_ctx: &UnivCtx, global_ctx: &GlobalCtx) -> ExprEnv {
@@ -676,13 +676,7 @@ impl ExprAnon {
         }
       })),
       (100, Box::new(|_| {
-        let mut env = Env::new();
-        let univ: Univ = arbitrary_univ(&mut Gen::new(50), univ_ctx);
-        let univ_cid = univ.store(&mut env).unwrap();
-        ExprEnv {
-          expr: Expr::Sort(univ_cid),
-          env: env
-        }
+        arbitrary_sort(univ_ctx)
       })),
       (100, Box::new(|g| {
         ExprEnv {

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -571,6 +571,24 @@ impl ExprAnon {
             env: env
           }
         })),
+        (rec_freq.saturating_sub(25), Box::new(|g| {
+          let typ: ExprEnv = Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1)));
+          let trm: ExprEnv = Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1)));
+          let bod: ExprEnv = Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1)));
+          let mut env = typ.env;
+          env.extend(trm.env);
+          env.extend(bod.env);
+          ExprEnv {
+            expr:
+              Expr::Let(
+                arbitrary_ascii_name(g, 5),
+                Box::new(typ.expr),
+                Box::new(trm.expr),
+                Box::new(bod.expr)
+              ),
+            env: env
+          }
+        })),
         (rec_freq, Box::new(|g| {
           let typ: ExprEnv = Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1)));
           let trm: ExprEnv = Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1)));

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -512,15 +512,7 @@ impl ExprAnon {
     Gen,
   };
 
-  pub fn arbitrary_name(g: &mut Gen) -> Name {
-    let s: String = Arbitrary::arbitrary(g);
-    let mut s: String = s
-      .chars()
-      .filter(|x| char::is_ascii_alphabetic(x))
-      .collect();
-    s.truncate(1);
-    Name::from(format!("_{}", s))
-  }
+  use crate::name::tests::arbitrary_ascii_name;
 
   // TODO can I #[derive(Arbitrary)]?
   impl Arbitrary for BinderInfo {
@@ -550,7 +542,7 @@ impl ExprAnon {
         })),
         (rec_freq, Box::new(|g| {
           Expr::Pi(
-            arbitrary_name(g),
+            arbitrary_ascii_name(g, 5),
             Arbitrary::arbitrary(g),
             Box::new(Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1)))),
             Box::new(Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1))))
@@ -558,7 +550,7 @@ impl ExprAnon {
         })),
         (rec_freq, Box::new(|g| {
           Expr::Lam(
-            arbitrary_name(g),
+            arbitrary_ascii_name(g, 5),
             Arbitrary::arbitrary(g),
             Box::new(Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1)))),
             Box::new(Arbitrary::arbitrary(&mut Gen::new(g.size().saturating_sub(1))))

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -251,8 +251,8 @@ impl Expr {
       match bi {
         BinderInfo::Default => format!("({})", var),
         BinderInfo::Implicit => format!("{{{}}}", var),
-        BinderInfo::InstImplict => format!("[{}]", var),
-        BinderInfo::StrictImplict => format!("{{{{{}}}}}", var),
+        BinderInfo::InstImplicit => format!("[{}]", var),
+        BinderInfo::StrictImplicit => format!("{{{{{}}}}}", var),
       }
     }
 
@@ -377,8 +377,6 @@ impl Expr {
         format!("{}", lty)
       },
       Expr::Fix(_, expr) => {
-        // Not sure what this actually does, sorry
-        // Also name is not used here?
         format!("{}", expr.pretty(ind)) 
       },
     }

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -248,43 +248,6 @@ impl Expr {
     }
   }
 
-  /// The input `Vector : ∀ (A: Type) -> ∀ (n: Nat) -> Sort 0` with depth 1 returns:
-  ///   - string: `(A: Type)` 
-  ///   - type: `∀ (n: Nat) -> Sort 0`
-  /// This is useful for printing defs
-  /// sort of the inverse of parse_bound_expressions?
-  /// Note that this doesn't fail -- it just stops parsing if it hits a non-pi expr
-  pub fn parse_binders(&self, env: &Env, ind: bool, depth: Nat) -> (String, &Expr) {
-    // This feels slightly hacky
-    fn with_binders(var: String, bi: &BinderInfo) -> String {
-      match bi {
-        BinderInfo::Default => format!("({})", var),
-        BinderInfo::Implicit => format!("{{{}}}", var),
-        BinderInfo::InstImplicit => format!("[{}]", var),
-        BinderInfo::StrictImplicit => format!("{{{{{}}}}}", var),
-      }
-    }
-
-    if depth == Nat::from(0 as u32) {
-      ("".to_string(), self)
-    } else {
-      match self {
-        Expr::Pi(name, bi, typ, expr) => {
-          let bdd_var = with_binders(format!("{name} : {}", typ.pretty(env, ind)), bi);
-          let (binders, remaining) = expr.parse_binders(env, ind, Nat::from(u32::MAX));
-          (format!("{} {}", bdd_var, binders), remaining)
-        },
-        _ => ("".to_string(), self)
-      }
-    }
-    
-  }
-
-  /// this is the inverse of parse_bound_expression?
-  pub fn print_bound_expression(&self) -> String {
-    "".to_string()
-  }
-
   pub fn pretty(&self, env: &Env, ind: bool) -> String {
     
     fn is_atom(expr: &Expr) -> bool {

--- a/yatima-rs/src/expression.rs
+++ b/yatima-rs/src/expression.rs
@@ -20,6 +20,10 @@ use serde::{
   Serialize,
 };
 
+use im::{
+  Vector,
+};
+
 use alloc::{
   fmt,
   boxed::Box,
@@ -342,6 +346,42 @@ impl Expr {
         format!("{}", expr.pretty(env, ind)) 
       },
       _ => todo!() // Projections
+    }
+  }
+
+  pub fn get_internal_refs(&self) -> Vec<ConstCid> {
+    match self {
+      Expr::Const(name, cid, univs) => {
+        Vec::from(vec![*cid])
+      },
+      Expr::App(fun, arg) => {
+        let mut refs = fun.get_internal_refs();
+        refs.extend(arg.get_internal_refs());
+        refs
+      },
+      Expr::Lam(name, bi, typ, body) => {
+        let mut refs = typ.get_internal_refs();
+        refs.extend(body.get_internal_refs());
+        refs
+      },
+      Expr::Pi(name, bi, typ, body) => { 
+        let mut refs = typ.get_internal_refs();
+        refs.extend(body.get_internal_refs());
+        refs
+      },
+      Expr::Let(name, typ, expr, body) => {
+        let mut refs = typ.get_internal_refs();
+        refs.extend(expr.get_internal_refs());
+        refs.extend(body.get_internal_refs());
+        refs
+      },
+      Expr::Fix(_, expr) => {
+        expr.get_internal_refs()
+      },
+      Expr::Proj(idx, expr) => {
+        expr.get_internal_refs()
+      }
+      _ => Vec::<ConstCid>::new()
     }
   }
 }

--- a/yatima-rs/src/lib.rs
+++ b/yatima-rs/src/lib.rs
@@ -30,17 +30,14 @@ pub mod test {
 
   pub fn frequency<T, F: Fn(&mut Gen) -> T>(
     g: &mut Gen,
-    gens: Vec<(i64, F)>,
+    gens: Vec<(usize, F)>,
   ) -> T {
-    if gens.iter().any(|(v, _)| *v < 0) {
-      panic!("Negative weight");
-    }
-    let sum: i64 = gens.iter().map(|x| x.0).sum();
+    let sum: usize = gens.iter().map(|x| x.0).sum();
     let mut rng = rand::thread_rng();
-    let mut weight: i64 = rng.gen_range(1..=sum);
-    // let mut weight: i64 = g.rng.gen_range(1, sum);
+    let mut weight: usize = rng.gen_range(1..=sum);
+    // let mut weight: usize = g.rng.gen_range(1, sum);
     for gen in gens {
-      if weight - gen.0 <= 0 {
+      if weight <= gen.0  {
         return gen.1(g);
       }
       else {

--- a/yatima-rs/src/lib.rs
+++ b/yatima-rs/src/lib.rs
@@ -19,3 +19,34 @@ pub mod nat;
 pub mod parse;
 pub mod typechecker;
 pub mod universe;
+
+#[cfg(test)]
+pub mod test {
+  use quickcheck::{
+    Arbitrary,
+    Gen,
+  };
+  use rand::Rng;
+
+  pub fn frequency<T, F: Fn(&mut Gen) -> T>(
+    g: &mut Gen,
+    gens: Vec<(i64, F)>,
+  ) -> T {
+    if gens.iter().any(|(v, _)| *v < 0) {
+      panic!("Negative weight");
+    }
+    let sum: i64 = gens.iter().map(|x| x.0).sum();
+    let mut rng = rand::thread_rng();
+    let mut weight: i64 = rng.gen_range(1..=sum);
+    // let mut weight: i64 = g.rng.gen_range(1, sum);
+    for gen in gens {
+      if weight - gen.0 <= 0 {
+        return gen.1(g);
+      }
+      else {
+        weight -= gen.0;
+      }
+    }
+    panic!("Calculation error for weight = {}", weight);
+  }
+}

--- a/yatima-rs/src/name.rs
+++ b/yatima-rs/src/name.rs
@@ -69,3 +69,23 @@ impl<'de> Deserialize<'de> for Name {
     Ok(Name { inner: Rc::from(string.as_str()) })
   }
 }
+
+#[cfg(test)]
+pub mod tests {
+
+  use super::*;
+  use quickcheck::{
+    Arbitrary,
+    Gen,
+  };
+
+  pub fn arbitrary_ascii_name(g: &mut Gen, len: usize) -> Name {
+    let mut s: String = String::new();
+    while s.len() < len {
+      let i = (u32::arbitrary(g) % 26) + 97;
+      let c = unsafe { char::from_u32_unchecked(i) };
+      s.push(c)
+    }
+    Name::from(format!("{}", s))
+  }
+}

--- a/yatima-rs/src/name.rs
+++ b/yatima-rs/src/name.rs
@@ -79,13 +79,23 @@ pub mod tests {
     Gen,
   };
 
+  use crate::parse::utils::reserved_symbols;
+
   pub fn arbitrary_ascii_name(g: &mut Gen, len: usize) -> Name {
-    let mut s: String = String::new();
-    while s.len() < len {
-      let i = (u32::arbitrary(g) % 26) + 97;
-      let c = unsafe { char::from_u32_unchecked(i) };
-      s.push(c)
+    let mut s: String;
+    
+    loop {
+      s = String::new();
+      while s.len() < len {
+        let i = (u32::arbitrary(g) % 26) + 97;
+        let c = unsafe { char::from_u32_unchecked(i) };
+        s.push(c)
+      }
+      if !reserved_symbols().contains(&s) {
+        break;
+      }
     }
+
     Name::from(format!("{}", s))
   }
 }

--- a/yatima-rs/src/parse.rs
+++ b/yatima-rs/src/parse.rs
@@ -6,3 +6,4 @@ pub mod span;
 pub mod string;
 pub mod univ;
 pub mod utils;
+pub mod env;

--- a/yatima-rs/src/parse/constant.rs
+++ b/yatima-rs/src/parse/constant.rs
@@ -322,7 +322,7 @@ fn parse_const_inductive_decl(
       bind_ctx.clone(),
       global_ctx.clone(),
       env_ctx.clone(),
-      vec!['-'],
+      vec!['-', '→'],
     )(i)?;
 
     let mut bind_ctx = bind_ctx;
@@ -332,7 +332,7 @@ fn parse_const_inductive_decl(
     let (i, _) = parse_space(i)?;
 
     let (i, _) = if indices.len() != 0 {
-      let (i, _) = tag("->")(i)?;
+      let (i, _) = alt((tag("->"), tag("→")))(i)?;
       let (i, _) = parse_space(i)?;
       Ok((i, ()))
     }

--- a/yatima-rs/src/parse/constant.rs
+++ b/yatima-rs/src/parse/constant.rs
@@ -690,22 +690,22 @@ pub mod tests {
     });
   }
 
-  #[quickcheck]
-  fn prop_const_parse_print(x: ConstEnv) -> bool {
-    let s = x.cnst.pretty(&x.env, false).unwrap();
-    println!("input: \t\t{s}");
-    let res_env = Rc::new(RefCell::new(Env::new()));
-    let res = parse_const_inductive(dummy_global_ctx(), res_env.clone())(Span::new(&s));
-    match res {
-      Ok((_, y)) => {
-        println!("re-parsed: \t{}", y.pretty(&*res_env.borrow(), false).unwrap());
-        print!("ORIG:\n{:?}\nREPARSED:\n{:?}", x.cnst, y);
-        x.cnst == y
-      }
-      Err(e) => {
-        println!("err: {:?}", e);
-        false
-      }
-    }
-  }
+  //#[quickcheck]
+  //fn prop_const_parse_print(x: ConstEnv) -> bool {
+  //  let s = x.cnst.pretty(&x.env, false).unwrap();
+  //  println!("input: \t\t{s}");
+  //  let res_env = Rc::new(RefCell::new(Env::new()));
+  //  let res = parse_const_inductive(dummy_global_ctx(), res_env.clone())(Span::new(&s));
+  //  match res {
+  //    Ok((_, y)) => {
+  //      println!("re-parsed: \t{}", y.pretty(&*res_env.borrow(), false).unwrap());
+  //      print!("ORIG:\n{:?}\nREPARSED:\n{:?}", x.cnst, y);
+  //      x.cnst == y
+  //    }
+  //    Err(e) => {
+  //      println!("err: {:?}", e);
+  //      false
+  //    }
+  //  }
+  //}
 }

--- a/yatima-rs/src/parse/env.rs
+++ b/yatima-rs/src/parse/env.rs
@@ -29,7 +29,9 @@ pub fn parse_env(
           i = res.0;
           global_ctx.insert(cnst.name(), res.1);
         },
-        Err(_) => break Ok((i, ()))
+        Err(_) => {
+          break Ok((i, ()))
+        }
       }
     }
   }

--- a/yatima-rs/src/parse/env.rs
+++ b/yatima-rs/src/parse/env.rs
@@ -12,13 +12,13 @@ use crate::parse::{
 
 use nom::IResult;
 
-/// Parses each constant, storing them in the provided environment context.
-pub fn parse_env(
-  global_ctx: GlobalCtx,
+/// Parses each constant, storing them in the provided environment context
+/// and updating the given global context accordingly.
+pub fn parse_env<'a, 'b>(
+  global_ctx: &'b mut GlobalCtx,
   env_ctx: EnvCtx,
-) -> impl Fn(Span) -> IResult<Span, (), ParseError<Span>> {
+) -> impl FnMut(Span<'a>) -> IResult<Span<'a>, (), ParseError<Span<'a>>> + 'b { 
   move |i: Span| {
-    let mut global_ctx = global_ctx.clone();
     let mut i = i.clone();
     loop {
       (i, _) = parse_space(i)?;
@@ -53,7 +53,7 @@ pub mod tests {
     let s = x.pretty(false).unwrap();
     println!("input: \n{s}");
     let y = Rc::new(RefCell::new(Env::new()));
-    let res = parse_env(OrdMap::new(), y.clone())(Span::new(&s));
+    let res = parse_env(&mut OrdMap::new(), y.clone())(Span::new(&s));
     match res {
       Ok((_, _)) => {
         let y =  y.try_borrow().unwrap().clone();

--- a/yatima-rs/src/parse/env.rs
+++ b/yatima-rs/src/parse/env.rs
@@ -1,0 +1,161 @@
+use alloc::string::{
+  String,
+  ToString,
+};
+use im::{
+  OrdMap,
+  Vector,
+};
+use libipld::Cid;
+use num_traits::Zero;
+
+use core::cell::{
+  RefCell,
+  RefMut,
+};
+
+use core::ops::DerefMut;
+
+use crate::{
+  constant::{
+    Const,
+    DefSafety,
+    QuotKind,
+  },
+  environment::{
+    ConstAnonCid,
+    ConstCid,
+    ConstMetaCid,
+    Env,
+    EnvError,
+    ExprCid,
+    CONST_ANON,
+    CONST_META,
+  },
+  expression::{
+    BinderInfo,
+    Expr,
+    LitType,
+    Literal,
+  },
+  name::Name,
+  nat::Nat,
+  parse::{
+    constant::parse_const,
+    base::parse_multibase,
+    error::{
+      throw_err,
+      ParseError,
+      ParseErrorKind,
+    },
+    expr::parse_bound_expression,
+    span::Span,
+    string::parse_string,
+    univ::parse_univ,
+    utils::{
+      parse_builtin_symbol_end,
+      parse_name,
+      parse_nat,
+      parse_space,
+      parse_space1,
+      parse_u8,
+      store_const,
+      BindCtx,
+      EnvCtx,
+      GlobalCtx,
+      UnivCtx,
+    },
+  },
+  universe::Univ,
+};
+use nom::{
+  branch::alt,
+  bytes::complete::{
+    tag,
+    take_till,
+    take_till1,
+  },
+  character::complete::{
+    digit1,
+    multispace0,
+    multispace1,
+    satisfy,
+  },
+  combinator::{
+    eof,
+    map,
+    opt,
+    peek,
+    success,
+    value,
+  },
+  error::context,
+  multi::{
+    many0,
+    many1,
+    separated_list1,
+  },
+  sequence::{
+    delimited,
+    preceded,
+    terminated,
+  },
+  Err,
+  IResult,
+};
+
+use super::expr::{
+  parse_binders0,
+  parse_expr,
+  parse_expr_apps,
+};
+
+/// Parses each constant, storing them in the provided environment context.
+pub fn parse_env(
+  global_ctx: GlobalCtx,
+  env_ctx: EnvCtx,
+) -> impl Fn(Span) -> IResult<Span, (), ParseError<Span>> {
+  move |i: Span| {
+    let mut global_ctx = global_ctx.clone();
+    let mut i = i.clone();
+    loop {
+      (i, _) = parse_space(i)?;
+      match &parse_const(global_ctx.clone(), env_ctx.clone())(i) {
+        Ok((_, cnst)) => {
+          let res = store_const(env_ctx.clone(), cnst.clone(), i)?;
+          i = res.0;
+          global_ctx.insert(cnst.name(), res.1);
+        },
+        Err(_) => break Ok((i, ()))
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+pub mod tests {
+  use super::*;
+
+  use alloc::rc::Rc;
+
+  use crate::expression::tests::dummy_global_ctx;
+
+  #[quickcheck]
+  fn prop_env_parse_print(x: Env) -> bool {
+    let s = x.pretty(false).unwrap();
+    println!("input: \t\t{s}");
+    let y = Rc::new(RefCell::new(Env::new()));
+    let res = parse_env(dummy_global_ctx(), y.clone())(Span::new(&s));
+    match res {
+      Ok((_, _)) => {
+        let y =  y.try_borrow().unwrap().clone();
+        println!("re-parsed: \t{}", y.pretty(false).unwrap());
+        x == y
+      }
+      Err(e) => {
+        println!("err: {:?}", e);
+        false
+      }
+    }
+  }
+}

--- a/yatima-rs/src/parse/env.rs
+++ b/yatima-rs/src/parse/env.rs
@@ -1,114 +1,16 @@
-use alloc::string::{
-  String,
-  ToString,
-};
-use im::{
-  OrdMap,
-  Vector,
-};
-use libipld::Cid;
-use num_traits::Zero;
-
-use core::cell::{
-  RefCell,
-  RefMut,
+use crate::parse::{
+  error::ParseError,
+  span::Span,
+  constant::parse_const,
+  utils::{
+    parse_space,
+    store_const,
+    EnvCtx,
+    GlobalCtx,
+  }
 };
 
-use core::ops::DerefMut;
-
-use crate::{
-  constant::{
-    Const,
-    DefSafety,
-    QuotKind,
-  },
-  environment::{
-    ConstAnonCid,
-    ConstCid,
-    ConstMetaCid,
-    Env,
-    EnvError,
-    ExprCid,
-    CONST_ANON,
-    CONST_META,
-  },
-  expression::{
-    BinderInfo,
-    Expr,
-    LitType,
-    Literal,
-  },
-  name::Name,
-  nat::Nat,
-  parse::{
-    constant::parse_const,
-    base::parse_multibase,
-    error::{
-      throw_err,
-      ParseError,
-      ParseErrorKind,
-    },
-    expr::parse_bound_expression,
-    span::Span,
-    string::parse_string,
-    univ::parse_univ,
-    utils::{
-      parse_builtin_symbol_end,
-      parse_name,
-      parse_nat,
-      parse_space,
-      parse_space1,
-      parse_u8,
-      store_const,
-      BindCtx,
-      EnvCtx,
-      GlobalCtx,
-      UnivCtx,
-    },
-  },
-  universe::Univ,
-};
-use nom::{
-  branch::alt,
-  bytes::complete::{
-    tag,
-    take_till,
-    take_till1,
-  },
-  character::complete::{
-    digit1,
-    multispace0,
-    multispace1,
-    satisfy,
-  },
-  combinator::{
-    eof,
-    map,
-    opt,
-    peek,
-    success,
-    value,
-  },
-  error::context,
-  multi::{
-    many0,
-    many1,
-    separated_list1,
-  },
-  sequence::{
-    delimited,
-    preceded,
-    terminated,
-  },
-  Err,
-  IResult,
-};
-
-use super::expr::{
-  parse_binders0,
-  parse_expr,
-  parse_expr_apps,
-};
+use nom::IResult;
 
 /// Parses each constant, storing them in the provided environment context.
 pub fn parse_env(
@@ -139,6 +41,9 @@ pub mod tests {
   use alloc::rc::Rc;
 
   use crate::expression::tests::dummy_global_ctx;
+
+  use crate::environment::Env;
+  use core::cell::RefCell;
 
   #[quickcheck]
   fn prop_env_parse_print(x: Env) -> bool {

--- a/yatima-rs/src/parse/expr.rs
+++ b/yatima-rs/src/parse/expr.rs
@@ -697,6 +697,12 @@ pub fn parse_expr(
       parse_expr_lit(),
       parse_expr_lty(),
       parse_expr_sort(univ_ctx.clone(), env_ctx.clone()),
+      parse_expr_let(
+        univ_ctx.clone(),
+        bind_ctx.clone(),
+        global_ctx.clone(),
+        env_ctx.clone(),
+      ),
       parse_expr_const(
         univ_ctx.clone(),
         bind_ctx.clone(),

--- a/yatima-rs/src/parse/expr.rs
+++ b/yatima-rs/src/parse/expr.rs
@@ -217,7 +217,12 @@ pub fn parse_expr_sort(
   env_ctx: EnvCtx,
 ) -> impl Fn(Span) -> IResult<Span, Expr, ParseError<Span>> {
   move |from: Span| {
-    let (i, _) = tag("Sort")(from)?;
+    let (i, res) = opt(tag("Prop"))(from)?;
+    if let Some(_) = res {
+      let (i, cid) = store_univ(env_ctx.clone(), Univ::Zero, i)?;
+      return Ok((i, Expr::Sort(cid)))
+    }
+    let (i, _) = tag("Sort")(i)?;
     let (i, _) = parse_space(i)?;
     let (i, u) = parse_univ(univ_ctx.clone())(i)?;
     let (i, cid) = store_univ(env_ctx.clone(), u, i)?;

--- a/yatima-rs/src/parse/expr.rs
+++ b/yatima-rs/src/parse/expr.rs
@@ -734,7 +734,7 @@ pub mod tests {
 
   use crate::expression::tests::{dummy_univ_ctx, dummy_global_ctx, dummy_const_cid};
 
-  use crate::expression::ExprEnv;
+  use crate::expression::tests::ExprEnv;
 
   use rand::Rng;
 

--- a/yatima-rs/src/parse/expr.rs
+++ b/yatima-rs/src/parse/expr.rs
@@ -638,7 +638,7 @@ pub fn parse_expr_let(
   move |from: Span| {
     let (i, _) = tag("let")(from)?;
     let (i, _) = parse_space(i)?;
-    let (i, rec) = opt(tag("rec"))(i)?;
+    let (i, rec) = opt(preceded(tag("rec"), alt((tag(" "), tag("\n")))))(i)?;
     let (i, _) = parse_space(i)?;
     let (i, nam) = parse_name(i)?;
     let rec = rec.map(|_| nam.clone());
@@ -1092,6 +1092,20 @@ pub mod tests {
     println!("{:?}", res);
     assert!(res.is_ok());
   }
+
+  #[test]
+  fn test_parse_let() {
+    let env_ctx = Rc::new(RefCell::new(Env::new()));
+    fn test(env_ctx: EnvCtx, i: &str) -> IResult<Span, Expr, ParseError<Span>> {
+      parse_expr(Vector::new(), Vector::new(), OrdMap::new(), env_ctx)(
+        Span::new(i),
+      )
+    }
+    let res = test(env_ctx.clone(), "let recname : Sort 0 := #Str in recname");
+    print!("{:?}", res);
+    assert!(res.is_ok());
+  }
+
   #[test]
   fn test_parse_lam() {
     fn test(i: &str) -> IResult<Span, Expr, ParseError<Span>> {

--- a/yatima-rs/src/parse/expr.rs
+++ b/yatima-rs/src/parse/expr.rs
@@ -1237,6 +1237,14 @@ pub mod tests {
           Box::new(inst_vars(univ_ctx, bind_ctx, global_ctx, env_ctx, *typ)),
           Box::new(inst_vars(univ_ctx, &new_bind_ctx, global_ctx, env_ctx, *bod)))
       }
+      Expr::Let(name, typ, trm, bod) => {
+        let mut new_bind_ctx = bind_ctx.clone();
+        new_bind_ctx.push_front(name.clone());
+        Expr::Let(name.clone(),
+          Box::new(inst_vars(univ_ctx, bind_ctx, global_ctx, env_ctx, *typ)),
+          Box::new(inst_vars(univ_ctx, bind_ctx, global_ctx, env_ctx, *trm)),
+          Box::new(inst_vars(univ_ctx, &new_bind_ctx, global_ctx, env_ctx, *bod)))
+      }
       _ => expr
     }
   }

--- a/yatima-rs/src/parse/expr.rs
+++ b/yatima-rs/src/parse/expr.rs
@@ -34,6 +34,7 @@ use crate::{
       parse_name,
       parse_nat,
       parse_space,
+      parse_space1,
       parse_u8,
       store_univ,
       BindCtx,
@@ -638,7 +639,7 @@ pub fn parse_expr_let(
   move |from: Span| {
     let (i, _) = tag("let")(from)?;
     let (i, _) = parse_space(i)?;
-    let (i, rec) = opt(preceded(tag("rec"), alt((tag(" "), tag("\n")))))(i)?;
+    let (i, rec) = opt(preceded(tag("rec"), parse_space1))(i)?;
     let (i, _) = parse_space(i)?;
     let (i, nam) = parse_name(i)?;
     let rec = rec.map(|_| nam.clone());

--- a/yatima-rs/src/parse/expr.rs
+++ b/yatima-rs/src/parse/expr.rs
@@ -727,6 +727,8 @@ pub mod tests {
 
   use crate::expression::tests::{dummy_univ_ctx, dummy_global_ctx, dummy_const_cid};
 
+  use crate::expression::ExprEnv;
+
   use rand::Rng;
 
   use super::*;
@@ -1240,14 +1242,15 @@ pub mod tests {
   }
 
   #[quickcheck]
-  fn prop_expr_parse_print(x: Expr) -> bool {
-    let x = inst_vars(&dummy_univ_ctx(), &Vector::new(), &dummy_global_ctx(), &Rc::new(RefCell::new(Env::new())), x);
-    let s = x.pretty(false);
+  fn prop_expr_parse_print(x: ExprEnv) -> bool {
+    let env = x.env;
+    let x = inst_vars(&dummy_univ_ctx(), &Vector::new(), &dummy_global_ctx(), &Rc::new(RefCell::new(Env::new())), x.expr);
+    let s = x.pretty(&env, false);
     println!("input: \t\t{s}");
     let res = parse_expr_apps(dummy_univ_ctx(), Vector::new(), dummy_global_ctx(), Rc::new(RefCell::new(Env::new())))(Span::new(&s));
     match res {
       Ok((_, y)) => {
-        println!("re-parsed: \t{}", y.pretty(false));
+        println!("re-parsed: \t{}", y.pretty(&env, false));
         x == y
       }
       Err(e) => {

--- a/yatima-rs/src/parse/univ.rs
+++ b/yatima-rs/src/parse/univ.rs
@@ -285,4 +285,18 @@ pub mod tests {
       ))))),
     );
   }
+  use crate::universe::tests::dummy_univ_ctx;
+
+  #[quickcheck]
+  fn prop_univ_parse_print(x: Univ) -> bool {
+    let s = x.pretty(false);
+    let res = parse_univ(dummy_univ_ctx())(Span::new(&s));
+    match res {
+      Ok((_, y)) => x == y,
+      Err(e) => {
+        println!("err: {:?}", e);
+        false
+      }
+    }
+  }
 }

--- a/yatima-rs/src/parse/univ.rs
+++ b/yatima-rs/src/parse/univ.rs
@@ -285,6 +285,7 @@ pub mod tests {
       ))))),
     );
   }
+  
   use crate::universe::tests::dummy_univ_ctx;
 
   #[quickcheck]

--- a/yatima-rs/src/parse/utils.rs
+++ b/yatima-rs/src/parse/utils.rs
@@ -15,6 +15,7 @@ use crate::{
     ExprCid,
     UnivCid,
   },
+  constant::Const,
   expression::{
     Expr,
     BinderInfo,
@@ -334,6 +335,23 @@ pub fn store_expr(
     Err::Error(ParseError::new(i, ParseErrorKind::Env(format!("{:?}", e))))
   })?;
   Ok((i, expr))
+}
+
+pub fn store_const(
+  env_ctx: EnvCtx,
+  cnst: Const,
+  i: Span,
+) -> IResult<Span, ConstCid, ParseError<Span>> {
+  let mut env = env_ctx.try_borrow_mut().map_err(|e| {
+    Err::Error(ParseError::new(
+      i,
+      ParseErrorKind::EnvBorrowMut(format!("{}", e)),
+    ))
+  })?;
+  let cnstcid = cnst.store(env.deref_mut()).map_err(|e| {
+    Err::Error(ParseError::new(i, ParseErrorKind::Env(format!("{:?}", e))))
+  })?;
+  Ok((i, cnstcid))
 }
 
 /// The input `Vector : ∀ (A: Type) -> ∀ (n: Nat) -> Sort 0` with depth 1 returns:

--- a/yatima-rs/src/parse/utils.rs
+++ b/yatima-rs/src/parse/utils.rs
@@ -15,7 +15,10 @@ use crate::{
     ExprCid,
     UnivCid,
   },
-  expression::Expr,
+  expression::{
+    Expr,
+    BinderInfo,
+  },
   name::Name,
   nat::Nat,
   universe::Univ,
@@ -331,4 +334,42 @@ pub fn store_expr(
     Err::Error(ParseError::new(i, ParseErrorKind::Env(format!("{:?}", e))))
   })?;
   Ok((i, expr))
+}
+
+/// The input `Vector : ∀ (A: Type) -> ∀ (n: Nat) -> Sort 0` with depth 1 returns:
+///   - string: `(A: Type)` 
+///   - type: `∀ (n: Nat) -> Sort 0`
+/// This is useful for printing defs
+/// sort of the inverse of parse_bound_expressions?
+/// Note that this doesn't fail -- it just stops parsing if it hits a non-pi expr
+pub fn get_binders<'a>(expr: &'a Expr, depth: Option<usize>) -> (Vec<((Name, BinderInfo), Expr)>, &'a Expr) {
+
+  let mut ret = Vec::new();
+  let mut expr = expr;
+  let mut curr_depth = 0;
+
+  loop {
+    if let Some(d) = depth { if curr_depth == d { break } }
+    match &expr {
+      Expr::Pi(name, bi, typ, rem_expr) => {
+        ret.push(((name.clone(), *bi), *typ.clone()));
+        expr = rem_expr;
+      },
+      _ => break
+    }
+
+    curr_depth = curr_depth + 1;
+  }
+
+  (ret, expr)
+}
+
+// This feels slightly hacky
+pub fn with_binders(var: String, bi: &BinderInfo) -> String {
+  match bi {
+    BinderInfo::Default => format!("({})", var),
+    BinderInfo::Implicit => format!("{{{}}}", var),
+    BinderInfo::InstImplicit => format!("[{}]", var),
+    BinderInfo::StrictImplicit => format!("{{{{{}}}}}", var),
+  }
 }

--- a/yatima-rs/src/typechecker/expression.rs
+++ b/yatima-rs/src/typechecker/expression.rs
@@ -85,8 +85,8 @@ pub enum Const {
   Inductive {
     uvars: Nat,
     typ: ExprPtr,
-    params: Nat,
-    indices: Nat,
+    params: usize,
+    indices: usize,
     ctors: Vec<(Name, Rc<Expr>)>,
     recr: bool,
     safe: bool,

--- a/yatima-rs/src/typechecker/from_anon.rs
+++ b/yatima-rs/src/typechecker/from_anon.rs
@@ -138,8 +138,8 @@ pub fn const_from_anon(const_cid: &ConstAnonCid, cid_env: &Env, conv_env: &mut C
     ConstAnon::Recursor { lvl, ind, typ, params, indices, motives, minors, rules, k, safe } => {
       let ind = const_from_anon(ind, cid_env, conv_env);
       let typ = expr_from_anon(typ, cid_env, conv_env);
-      let params = TryFrom::try_from(params).unwrap();
-      let indices = TryFrom::try_from(indices).unwrap();
+      let params = TryFrom::try_from(*params).unwrap();
+      let indices = TryFrom::try_from(*indices).unwrap();
       let motives = TryFrom::try_from(motives).unwrap();
       let minors = TryFrom::try_from(minors).unwrap();
       let mut t_rules = HashMap::new();

--- a/yatima-rs/src/typechecker/from_anon.rs
+++ b/yatima-rs/src/typechecker/from_anon.rs
@@ -113,8 +113,8 @@ pub fn const_from_anon(const_cid: &ConstAnonCid, cid_env: &Env, conv_env: &mut C
       Rc::new(Const::Inductive {
         uvars: lvl.clone(),
         typ,
-        params: params.clone(),
-        indices: indices.clone(),
+        params: *params,
+        indices: *indices,
         ctors: t_ctors,
         recr: *recr,
         safe: *safe,

--- a/yatima-rs/src/universe.rs
+++ b/yatima-rs/src/universe.rs
@@ -17,6 +17,7 @@ use serde::{
 
 use libipld::serde::to_ipld;
 
+use alloc::fmt;
 use multihash::{
   Code,
   MultihashDigest,
@@ -83,6 +84,30 @@ impl Univ {
     env.insert_univ_cache(cid, self);
     Ok(cid)
   }
+
+  pub fn pretty(&self, ind: bool) -> String {
+    fn succs(x: &Univ, count: usize, ind: bool) -> String {
+      match x {
+        Univ::Succ(p) => succs(p, count + 1, ind),
+        Univ::Zero => format!("{}", count),
+        x => format!("({} + {})", x.pretty(ind), count),
+      }
+    }
+    match self {
+      Univ::Zero => format!("0"),
+      Univ::Param(n, i) if ind => format!("{}^{}", n, i),
+      Univ::Param(n, _) => format!("{}", n),
+      Univ::Succ(p) => succs(p, 1, ind),
+      Univ::IMax(l, r) => format!("(imax {} {})", l.pretty(ind), r.pretty(ind)),
+      Univ::Max(l, r) => format!("(max {} {})", l.pretty(ind), r.pretty(ind)),
+    }
+  }
+}
+
+impl fmt::Display for Univ {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}", self.pretty(false))
+  }
 }
 
 /// IPLD Serialization:
@@ -142,5 +167,84 @@ impl UnivAnon {
     let cid = self.cid()?;
     env.insert_univ_anon(cid, self);
     Ok(cid)
+  }
+}
+
+#[cfg(test)]
+pub mod tests {
+  use super::*;
+  use crate::{
+    name::tests::arbitrary_ascii_name,
+    test::frequency,
+  };
+  use im::Vector;
+  use quickcheck::{
+    Arbitrary,
+    Gen,
+  };
+
+  pub fn dummy_univ_ctx() -> Vector<Name> {
+    Vector::from(vec![Name::from("w"), Name::from("v"), Name::from("u")])
+  }
+
+  impl Arbitrary for Univ {
+    fn arbitrary(g: &mut Gen) -> Self {
+      let input: Vec<(i64, Box<dyn Fn(&mut Gen) -> Univ>)> = vec![
+        (10, Box::new(|_| Univ::Zero)),
+        (
+          10,
+          Box::new(|g| {
+            let i = usize::arbitrary(g) % 3;
+            let n = &dummy_univ_ctx()[i];
+            Univ::Param(n.clone(), i.into())
+          }),
+        ),
+        (7, Box::new(|g| Univ::Succ(Box::new(Arbitrary::arbitrary(g))))),
+        (
+          6,
+          Box::new(|g| {
+            Univ::Max(
+              Box::new(Arbitrary::arbitrary(g)),
+              Box::new(Arbitrary::arbitrary(g)),
+            )
+          }),
+        ),
+        (
+          6,
+          Box::new(|g| {
+            Univ::IMax(
+              Box::new(Arbitrary::arbitrary(g)),
+              Box::new(Arbitrary::arbitrary(g)),
+            )
+          }),
+        ),
+      ];
+      frequency(g, input)
+    }
+  }
+
+  #[test]
+  fn test_print_univ() {
+    fn test(x: Univ, i: &str) { assert_eq!(x.pretty(true), String::from(i)) }
+    test(Univ::Zero, "0");
+    test(Univ::Succ(Box::new(Univ::Zero)), "1");
+    test(
+      Univ::Succ(Box::new(Univ::Param(Name::from("u"), 0u64.into()))),
+      "(u^0 + 1)",
+    );
+    test(
+      Univ::IMax(
+        Box::new(Univ::Param(Name::from("u"), 0u64.into())),
+        Box::new(Univ::Param(Name::from("v"), 1u64.into())),
+      ),
+      "(imax u^0 v^1)",
+    );
+    test(
+      Univ::Max(
+        Box::new(Univ::Param(Name::from("u"), 0u64.into())),
+        Box::new(Univ::Param(Name::from("v"), 1u64.into())),
+      ),
+      "(max u^0 v^1)",
+    );
   }
 }

--- a/yatima-rs/src/universe.rs
+++ b/yatima-rs/src/universe.rs
@@ -190,18 +190,16 @@ pub mod tests {
   impl Arbitrary for Univ {
     fn arbitrary(g: &mut Gen) -> Self {
       let input: Vec<(usize, Box<dyn Fn(&mut Gen) -> Univ>)> = vec![
-        (10, Box::new(|_| Univ::Zero)),
-        (
-          10,
+        (100, Box::new(|_| Univ::Zero)),
+        (100,
           Box::new(|g| {
             let i = usize::arbitrary(g) % 3;
             let n = &dummy_univ_ctx()[i];
             Univ::Param(n.clone(), i.into())
           }),
         ),
-        (7, Box::new(|g| Univ::Succ(Box::new(Arbitrary::arbitrary(g))))),
-        (
-          6,
+        (g.size().saturating_sub(30), Box::new(|g| Univ::Succ(Box::new(Arbitrary::arbitrary(g))))),
+        (g.size().saturating_sub(40),
           Box::new(|g| {
             Univ::Max(
               Box::new(Arbitrary::arbitrary(g)),
@@ -209,8 +207,7 @@ pub mod tests {
             )
           }),
         ),
-        (
-          6,
+        (g.size().saturating_sub(40),
           Box::new(|g| {
             Univ::IMax(
               Box::new(Arbitrary::arbitrary(g)),

--- a/yatima-rs/src/universe.rs
+++ b/yatima-rs/src/universe.rs
@@ -189,7 +189,7 @@ pub mod tests {
 
   impl Arbitrary for Univ {
     fn arbitrary(g: &mut Gen) -> Self {
-      let input: Vec<(i64, Box<dyn Fn(&mut Gen) -> Univ>)> = vec![
+      let input: Vec<(usize, Box<dyn Fn(&mut Gen) -> Univ>)> = vec![
         (10, Box::new(|_| Univ::Zero)),
         (
           10,

--- a/yatima-rs/src/universe.rs
+++ b/yatima-rs/src/universe.rs
@@ -191,9 +191,14 @@ pub mod tests {
       (100, Box::new(|_| Univ::Zero)),
       (100,
         Box::new(|g| {
-          let i = usize::arbitrary(g) % univ_ctx.len();
-          let n = &univ_ctx[i];
-          Univ::Param(n.clone(), i.into())
+          if univ_ctx.len() > 0 {
+            let i = usize::arbitrary(g) % univ_ctx.len();
+            let n = &univ_ctx[i];
+            Univ::Param(n.clone(), i.into())
+          }
+          else {
+            Univ::Zero
+          }
         }),
       ),
       (g.size().saturating_sub(30), Box::new(|g| Univ::Succ(Box::new(arbitrary_univ(g, univ_ctx))))),


### PR DESCRIPTION
**Problem**: We want to be able to print out `Univ`/`Expr`/`Const` for debugging purposes. We also want to make sure that the parser and printer are compatible with one another by adding `quickcheck` tests of the `x == parse(print(x))` roundtrip.

**Solution**:
- Add `Arbitrary` generators (or equivalent functions) for:
  - [x] `Name`
  - [x] `Univ`
  - [x] `Expr`
  - [x] `Const`
  - [x] `Env`
- Write a `pretty(&self, debug: bool) -> String` function for
  - [x] `Univ`
  - [x] `Expr`
  - [x] `Const`
  - [x] `Env`
- Write a `quickcheck` prop test using the generator, parser and printer for:
  - [x] `Univ`
  - [x] `Expr`
  - [x] `Const`
  - [x] `Env`

Note: We can look at https://github.com/yatima-inc/yatima-lang-alpha/blob/f7534b258202c79416c26f498d19b4e921a56ee8/core/src/term.rs#L394 for an idea of how to implement a nice pretty-printer, although this is a little boiler-plate heavy