### PR TITLE
Computing a `delta` environment to optimize the compilation process

### DIFF
--- a/Yatima/Compiler/FromLean.lean
+++ b/Yatima/Compiler/FromLean.lean
@@ -486,6 +486,7 @@ def buildEnv (constMap : Lean.ConstMap)
   return (← get).env
 
 def extractEnv
+  (delta : Lean.ConstMap)
   (map : Lean.ConstMap)
   (printLean : Bool)
   (printYatima : Bool)
@@ -500,7 +501,7 @@ def extractEnv
     CompileM.run 
       ⟨map, [], [], Std.RBMap.ofList nss.join, []⟩
       default 
-      (buildEnv map printLean printYatima)
+      (buildEnv (filterConstants delta) printLean printYatima)
   | .error e => throw e
 
 end Yatima.Compiler

--- a/examples/Foo.lean
+++ b/examples/Foo.lean
@@ -1,10 +1,3 @@
-prelude
-
-def id (A : Type) (x : A) : A := x
-
-inductive Unit where
-| unit
-
 inductive Bar
   | hi | bye
 


### PR DESCRIPTION
Computing a 'delta' environment, composed solely by new declarations the user wants to compile. the full environment is still used as a pool of declarations to be used on demand.

Closes #70
Closes #74 