### PR TITLE
Fixing delta computation

### DIFF
--- a/Yatima/Compiler/Frontend.lean
+++ b/Yatima/Compiler/Frontend.lean
@@ -561,10 +561,9 @@ def runFrontend (code fileName : String) (printLean printYatima : Bool) :
   Lean.initSearchPath $ ← Lean.findSysroot
   let (env, ok) ← Lean.Elab.runFrontend code .empty fileName default
   if ok then
-    let emptyFile := getImportedInitModules env |>.foldl (init := "")
+    let importFile := getImportedInitModules env |>.foldl (init := "prelude\n")
       fun acc m => s!"{acc}import {m}\n"
-    dbg_trace emptyFile
-    let (env₀, _) ← Lean.Elab.runFrontend default .empty emptyFile default
+    let (env₀, _) ← Lean.Elab.runFrontend importFile .empty default default
     match extractEnv env.constants env₀.constants printLean printYatima with
     | .ok env => return .ok env
     | .error e => return .error e

--- a/Yatima/Compiler/Frontend.lean
+++ b/Yatima/Compiler/Frontend.lean
@@ -549,19 +549,13 @@ def extractEnv (map map₀ : Lean.ConstMap) (printLean printYatima : Bool) :
       (buildEnv delta printLean printYatima)
   | .error e => throw e
 
-def getImportedInitModules (env : Lean.Environment) : Array Lean.Name :=
-  env.header.moduleNames.filter fun name =>
-    match name with
-    | .str `Init .. => true
-    | .num `Init .. => true
-    | _             => false
-
 def runFrontend (code fileName : String) (printLean printYatima : Bool) :
     IO $ Except String Env := do
   Lean.initSearchPath $ ← Lean.findSysroot
   let (env, ok) ← Lean.Elab.runFrontend code .empty fileName default
   if ok then
-    let importFile := getImportedInitModules env |>.foldl (init := "prelude\n")
+    let importFile := env.header.imports.map (·.module) |>.foldl
+      (init := "prelude\n")
       fun acc m => s!"{acc}import {m}\n"
     let (env₀, _) ← Lean.Elab.runFrontend importFile .empty default default
     match extractEnv env.constants env₀.constants printLean printYatima with

--- a/examples/Foo.lean
+++ b/examples/Foo.lean
@@ -1,38 +1,33 @@
-prelude
 
-universe u v w
+mutual
+  unsafe def A : Nat → Nat
+  | 0 => 0
+  | n + 1 => B n + E n + C n + 1
 
-@[inline] def id {α : Sort u} (a : α) : α := a
+  unsafe def C : Nat → Nat
+  | 0 => 0
+  | n + 1 => B n + F n + A n + 1
 
--- mutual
---   unsafe def A : Nat → Nat
---   | 0 => 0
---   | n + 1 => B n + E n + C n + 1
+  unsafe def B : Nat → Nat
+  | 0 => 0
+  | n + 1 => C n + 2
 
---   unsafe def C : Nat → Nat
---   | 0 => 0
---   | n + 1 => B n + F n + A n + 1
+  unsafe def E : Nat → Nat 
+  | 0 => 0 
+  | n + 1 => B n + A n + F n + 1
 
---   unsafe def B : Nat → Nat
---   | 0 => 0
---   | n + 1 => C n + 2
+  unsafe def F : Nat → Nat 
+  | 0 => 0 
+  | n + 1 => B n + C n + E n + 1
 
---   unsafe def E : Nat → Nat 
---   | 0 => 0 
---   | n + 1 => B n + A n + F n + 1
+  unsafe def G : Nat → Nat 
+  | 0 => 0
+  | n + 1 => B n + F n + H n + 2
 
---   unsafe def F : Nat → Nat 
---   | 0 => 0 
---   | n + 1 => B n + C n + E n + 1
-
---   unsafe def G : Nat → Nat 
---   | 0 => 0
---   | n + 1 => B n + F n + H n + 2
-
---   unsafe def H : Nat → Nat 
---   | 0 => 0
---   | n + 1 => B n + E n + G n + 2
--- end 
+  unsafe def H : Nat → Nat 
+  | 0 => 0
+  | n + 1 => B n + E n + G n + 2
+end 
 
 
 -- A: bagcyb6egbqlcbb6kcu6vs3bema6tzlkeponxksunaj45aegt7i5ixaeh64ggg2wj

--- a/examples/Foo.lean
+++ b/examples/Foo.lean
@@ -1,33 +1,38 @@
+prelude
 
-mutual
-  unsafe def A : Nat → Nat
-  | 0 => 0
-  | n + 1 => B n + E n + C n + 1
+universe u v w
 
-  unsafe def C : Nat → Nat
-  | 0 => 0
-  | n + 1 => B n + F n + A n + 1
+@[inline] def id {α : Sort u} (a : α) : α := a
 
-  unsafe def B : Nat → Nat
-  | 0 => 0
-  | n + 1 => C n + 2
+-- mutual
+--   unsafe def A : Nat → Nat
+--   | 0 => 0
+--   | n + 1 => B n + E n + C n + 1
 
-  unsafe def E : Nat → Nat 
-  | 0 => 0 
-  | n + 1 => B n + A n + F n + 1
+--   unsafe def C : Nat → Nat
+--   | 0 => 0
+--   | n + 1 => B n + F n + A n + 1
 
-  unsafe def F : Nat → Nat 
-  | 0 => 0 
-  | n + 1 => B n + C n + E n + 1
+--   unsafe def B : Nat → Nat
+--   | 0 => 0
+--   | n + 1 => C n + 2
 
-  unsafe def G : Nat → Nat 
-  | 0 => 0
-  | n + 1 => B n + F n + H n + 2
+--   unsafe def E : Nat → Nat 
+--   | 0 => 0 
+--   | n + 1 => B n + A n + F n + 1
 
-  unsafe def H : Nat → Nat 
-  | 0 => 0
-  | n + 1 => B n + E n + G n + 2
-end 
+--   unsafe def F : Nat → Nat 
+--   | 0 => 0 
+--   | n + 1 => B n + C n + E n + 1
+
+--   unsafe def G : Nat → Nat 
+--   | 0 => 0
+--   | n + 1 => B n + F n + H n + 2
+
+--   unsafe def H : Nat → Nat 
+--   | 0 => 0
+--   | n + 1 => B n + E n + G n + 2
+-- end 
 
 
 -- A: bagcyb6egbqlcbb6kcu6vs3bema6tzlkeponxksunaj45aegt7i5ixaeh64ggg2wj


### PR DESCRIPTION
The current delta computation is wrong because we're running Lean's frontend on an empty file everytime, which causes Lean to import everything from `Init`.

Instead, we want to compute `env₀` based on a file that imports the same modules as the one we're compiling.