### PR TITLE
Remove the need for `lake env` before calling our yatima binary

### DIFF
--- a/examples/Foo.lean
+++ b/examples/Foo.lean
@@ -1,3 +1,4 @@
+import Yatima.Name
 
 mutual
   unsafe def A : Nat → Nat


### PR DESCRIPTION
This PR makes it easier for us to call our `yatima` binary by eliminating the need to say `lake env yatima ...`.

It does so by enhancing the call to `Lean.initSearchPath` with the extra list of paths to `olean` files, so our binary will understand imports of files that are not in `Init`.