### PR TITLE
bump to nightly 08-09 

### DIFF
--- a/Yatima/ForLurkRepo/DSL.lean
+++ b/Yatima/ForLurkRepo/DSL.lean
@@ -171,7 +171,6 @@ partial def elabLurkExpr : TSyntax `lurk_expr → TermElabM Expr
       mkAppM ``Lurk.Expr.ToExpr.toExpr #[e]
     else 
       throwUnsupportedSyntax 
-  | _ => throwUnsupportedSyntax
 end
 
 --#eval Name.mkSimple ""

--- a/Yatima/ForLurkRepo/FixName.lean
+++ b/Yatima/ForLurkRepo/FixName.lean
@@ -22,6 +22,12 @@ def validCharsTree : RBTree Char compare :=
     'q', 'r', 'w', 'x', 'Q', 'R', '-', ':',
     '_']
 
+def charToHex (c : Char) : String :=
+  let n  := Char.toNat c;
+  let d2 := n / 16;
+  let d1 := n % 16;
+  hexDigitRepr d2 ++ hexDigitRepr d1
+
 /-- Generates a sequence of valid characters in Lurk from a given character. -/
 def charToValidChars (c : Char) : List Char :=
   if validCharsTree.contains c then [c]

--- a/Yatima/ForLurkRepo/SExpr.lean
+++ b/Yatima/ForLurkRepo/SExpr.lean
@@ -124,7 +124,6 @@ partial def elabSExpr : Syntax → TermElabM Expr
       mkAppM ``ToSExpr.toSExpr #[e]
     else 
       throwUnsupportedSyntax 
-  | _ => throwUnsupportedSyntax
   where 
     mkNameLit (name : String) := 
       mkAppM ``Name.mkSimple #[mkStrLit name]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -14,13 +14,13 @@ lean_exe yatima {
 lean_lib Yatima { roots := #[`Yatima] }
 
 require Ipld from git
-  "https://github.com/yatima-inc/Ipld.lean" @ "c77099a6151816687750d65fea71d8cee995f29c"
+  "https://github.com/yatima-inc/Ipld.lean" @ "66957120705d384ea2445fa080a8155eb3104ea7"
 
 require LSpec from git
-  "https://github.com/yatima-inc/LSpec.git" @ "77fc51697abeff937ffd20d2050723dc0fa1c8c0"
+  "https://github.com/yatima-inc/LSpec.git" @ "28c24d851c614b88f3c7f1874f29f393ee35ba8e"
 
 require YatimaStdLib from git
-  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "a2bbc9a48db7efd5d761a5b27f2cc6c1863b9622"
+  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "40568b0c3e58646dc525bee32ba7a42a80b993a1"
 
 require Cli from git
   "https://github.com/mhuisi/lean4-cli" @ "b0efab6f62d171b76d8fbed03e0abd3e38854589"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-07-31
+leanprover/lean4:nightly-2022-08-09

--- a/lean_packages/manifest.json
+++ b/lean_packages/manifest.json
@@ -1,4 +1,4 @@
-{"version": 1,
+{"version": 2,
  "packages":
  [{"url": "https://github.com/mhuisi/lean4-cli",
    "rev": "b0efab6f62d171b76d8fbed03e0abd3e38854589",


### PR DESCRIPTION
## Why

We want to generate and host our documentation using `doc-gen4` which requires a toolchain bump compatible with the latest DocGen4 commits.