### PR TITLE
Factoring out the converter to a proper mini-project

### DIFF
--- a/TestsUtils/CompileAndExtractTests.lean
+++ b/TestsUtils/CompileAndExtractTests.lean
@@ -1,10 +1,10 @@
 import LSpec
 import Yatima.Datatypes.Cid
 import Yatima.Compiler.Compiler
-import Yatima.Ipld.FromIpld
 import Yatima.Compiler.Printing
+import Yatima.Converter.Converter
 
-open LSpec Yatima Compiler FromIpld
+open LSpec Yatima Compiler Converter
 
 def compileAndExtractTests (fixture : String)
   (extractors : List (CompileState → TestSeq) := []) (setPaths : Bool := true) :
@@ -24,11 +24,11 @@ creates tests that assert that:
 -/
 
 def extractCidGroups (groups : List (List Lean.Name)) (stt : CompileState) :
-    Except String (Array (Array (Lean.Name × Ipld.ConstCid .Anon))) := Id.run do
+    Except String (Array (Array (Lean.Name × Ipld.ConstCid .anon))) := Id.run do
   let mut notFound : Array Lean.Name := #[]
-  let mut cidGroups : Array (Array (Lean.Name × Ipld.ConstCid .Anon)) := #[]
+  let mut cidGroups : Array (Array (Lean.Name × Ipld.ConstCid .anon)) := #[]
   for group in groups do
-    let mut cidGroup : Array (Lean.Name × Ipld.ConstCid .Anon) := #[]
+    let mut cidGroup : Array (Lean.Name × Ipld.ConstCid .anon) := #[]
     for name in group do
       match stt.cache.find? name with
       | none          => notFound := notFound.push name
@@ -124,7 +124,7 @@ def reindexConst (map : NatNatMap) : Const → Const
 
 def extractIpldRoundtripTests (stt : CompileState) : TestSeq :=
   withExceptOk "`FromIpld.extractConstArray` succeeds"
-    (FromIpld.extractConstArray stt.store) fun defns =>
+    (extractConstArray stt.store) fun defns =>
       withExceptOk "Pairing succeeds" (pairConstants stt.defns defns) $
         fun (pairs, map) => pairs.foldl (init := .done) fun tSeq (c₁, c₂) =>
           tSeq ++ test s!"{c₁.name} ({c₁.ctorName}) roundtrips" (reindexConst map c₁ == c₂)

--- a/Yatima.lean
+++ b/Yatima.lean
@@ -11,6 +11,9 @@ import Yatima.Compiler.CompileM
 import Yatima.Compiler.Compiler
 import Yatima.Compiler.Printing
 import Yatima.Compiler.Utils
+import Yatima.Converter.ConvertError
+import Yatima.Converter.ConvertM
+import Yatima.Converter.Converter
 import Yatima.Datatypes.Cid
 import Yatima.Datatypes.Const
 import Yatima.Datatypes.Expr
@@ -26,7 +29,6 @@ import Yatima.ForLurkRepo.Printing
 import Yatima.ForLurkRepo.SExpr
 import Yatima.ForLurkRepo.Tests
 import Yatima.ForLurkRepo.Utils
-import Yatima.Ipld.FromIpld
 import Yatima.Ipld.ToIpld
 import Yatima.Transpiler.LurkFunctions
 import Yatima.Transpiler.Test

--- a/Yatima/Converter/ConvertError.lean
+++ b/Yatima/Converter/ConvertError.lean
@@ -1,0 +1,28 @@
+inductive ConvertError where
+  | ipldError : ConvertError
+  | cannotStoreValue : ConvertError
+  | mutDefBlockFound : ConvertError
+  | mutIndBlockFound : ConvertError
+  | anonMetaMismatch : String → String → ConvertError
+  | cannotFindNameIdx : String → ConvertError
+  | constIdxOutOfRange : Nat → Nat → ConvertError
+  | invalidIndexDepth : Nat → Nat → ConvertError
+  | invalidMutBlock : String → ConvertError
+  | unexpectedConst : String → String → ConvertError
+  | defnsIdxNotFound : String → ConvertError
+  | mutRefFVNotFound : Nat → ConvertError
+  deriving Inhabited
+
+instance : ToString ConvertError where toString
+  | .anonMetaMismatch anon meta => s!"Anon/Meta mismatch: Anon is of kind {anon} but Meta is of kind {meta}"
+  | .ipldError => "IPLD broken"
+  | .cannotStoreValue => "Cannot store value"
+  | .mutDefBlockFound => "Found a mutual definition block inside an expression"
+  | .mutIndBlockFound => "Found a mutual inductive block inside an expression"
+  | .cannotFindNameIdx name => s!"Cannot find index for '{name}'"
+  | .constIdxOutOfRange i max => s!"Const index {i} out of range. Must be < {max}"
+  | .invalidIndexDepth i min => s!"Invalid mutual referencing free variable index {i}. Must be ≥ {min}"
+  | .invalidMutBlock type => s!"Invalid mutual block Ipld.Const reference, {type} found."
+  | .defnsIdxNotFound name => s!"Could not find {name} in index of definitions."
+  | .mutRefFVNotFound i => s!"Could not find index {i} in index of mutual referencing free variables."
+  | .unexpectedConst got exp => s!"Unexpected constant. Got {got} but expected {exp}"

--- a/Yatima/Converter/ConvertM.lean
+++ b/Yatima/Converter/ConvertM.lean
@@ -1,0 +1,53 @@
+import Yatima.Datatypes.Store
+import Yatima.Compiler.Utils
+import Yatima.Converter.ConvertError
+import YatimaStdLib.RBMap
+
+namespace Yatima
+
+namespace Converter
+
+open Std (RBMap)
+
+abbrev RecrCtx := RBMap (Nat × Option Nat) (Nat × Name) compare
+
+structure ConvertEnv where
+  store     : Ipld.Store
+  recrCtx   : RecrCtx
+  bindDepth : Nat
+  deriving Inhabited
+
+def ConvertEnv.init (store : Ipld.Store) : ConvertEnv :=
+  ⟨store, default, 0⟩
+
+structure ConvertState where
+  univ_cache  : RBMap UnivCid Univ compare
+  expr_cache  : RBMap ExprCid Expr compare
+  const_cache : RBMap ConstCid ConstIdx compare
+  defns       : Array Const
+  defnsIdx    : RBMap Name ConstIdx compare
+  deriving Inhabited
+
+abbrev ConvertM := ReaderT ConvertEnv <| EStateM ConvertError ConvertState
+
+def ConvertM.run (env : ConvertEnv) (ste : ConvertState) (m : ConvertM α) :
+    Except ConvertError ConvertState :=
+  match EStateM.run (ReaderT.run m env) ste with
+  | .ok _ stt  => .ok stt
+  | .error e _ => .error e
+
+def ConvertM.unwrap : Option A → ConvertM A :=
+  Option.option (throw .ipldError) pure
+
+def withResetBindDepth : ConvertM α → ConvertM α :=
+  withReader $ fun e => { e with bindDepth := 0 }
+
+def withRecrs (recrCtx : RecrCtx) : ConvertM α → ConvertM α :=
+  withReader $ fun e => { e with recrCtx }
+
+def withNewBind : ConvertM α → ConvertM α :=
+  withReader $ fun e => { e with bindDepth := e.bindDepth + 1 }
+
+namespace Converter
+
+namespace Yatima

--- a/Yatima/Datatypes/Cid.lean
+++ b/Yatima/Datatypes/Cid.lean
@@ -4,15 +4,18 @@ import Yatima.Datatypes.Kind
 namespace Yatima
 
 namespace Ipld
+
 def UNIV : (k : Kind) → UInt64
-  | .Anon => 0xC0DE0001
-  | .Meta => 0xC0DE0002
+  | .anon => 0xC0DE0001
+  | .meta => 0xC0DE0002
+
 def EXPR : (k : Kind) → UInt64
-  | .Anon => 0xC0DE0003
-  | .Meta => 0xC0DE0004
+  | .anon => 0xC0DE0003
+  | .meta => 0xC0DE0004
+
 def CONST : (k : Kind) → UInt64
-  | .Anon => 0xC0DE0005
-  | .Meta => 0xC0DE0006
+  | .anon => 0xC0DE0005
+  | .meta => 0xC0DE0006
 
 def ENV: UInt64 := 0xC0DE0007
 
@@ -25,7 +28,7 @@ structure AnonMeta (A : Type) (B : Type) : Type where
   meta : B
   deriving BEq, Ord, Inhabited
 
-abbrev Both (A : Kind → Type) := AnonMeta (A .Anon) (A .Meta)
+abbrev Both (A : Kind → Type) := AnonMeta (A .anon) (A .meta)
 
 end Ipld
 

--- a/Yatima/Datatypes/Const.lean
+++ b/Yatima/Datatypes/Const.lean
@@ -168,7 +168,7 @@ def Const.ctorName : Ipld.Const k → String
   | .mutDefBlock     _ => "mutual definition block"
   | .mutIndBlock     _ => "mutual inductive block"
 
-def Const.name : Ipld.Const .Meta → Name
+def Const.name : Ipld.Const .meta → Name
   | .axiom           x 
   | .theorem         x 
   | .opaque          x 

--- a/Yatima/Datatypes/Expr.lean
+++ b/Yatima/Datatypes/Expr.lean
@@ -175,7 +175,7 @@ def shiftVars (expr : Expr) (inc : Int) : Expr :=
     | pi name bind type body    => pi name bind (walk type) (walk body)
     | letE name type value body =>
       letE name (walk type) (walk value) (walk body)
-    | other                     => other -- All the rest of the cases are treated at once
+    | other => other -- All the rest of the cases are treated at once
   walk expr
 
 /--

--- a/Yatima/Datatypes/Kind.lean
+++ b/Yatima/Datatypes/Kind.lean
@@ -5,13 +5,13 @@ namespace Yatima
 namespace Ipld
 
 inductive Kind where
-  | Anon : Kind
-  | Meta : Kind
+  | anon : Kind
+  | meta : Kind
   deriving BEq, Inhabited
 
 instance : Coe Kind Bool where coe
-  | .Anon => .true
-  | .Meta => .false
+  | .anon => true
+  | .meta => false
 
 end Ipld
 

--- a/Yatima/Datatypes/Name.lean
+++ b/Yatima/Datatypes/Name.lean
@@ -1,5 +1,6 @@
 namespace Yatima
 
+/-- Just `Lean.Name` under the hood. -/
 abbrev Name := Lean.Name
 
 end Yatima

--- a/Yatima/Datatypes/Store.lean
+++ b/Yatima/Datatypes/Store.lean
@@ -8,13 +8,13 @@ open Std (RBMap RBTree) in
 structure Store where
   defns : RBTree (Both ConstCid) compare
 
-  univ_anon  : RBMap (UnivCid  .Anon) (Univ  .Anon) compare
-  expr_anon  : RBMap (ExprCid  .Anon) (Expr  .Anon) compare
-  const_anon : RBMap (ConstCid .Anon) (Const .Anon) compare
+  univ_anon  : RBMap (UnivCid  .anon) (Univ  .anon) compare
+  expr_anon  : RBMap (ExprCid  .anon) (Expr  .anon) compare
+  const_anon : RBMap (ConstCid .anon) (Const .anon) compare
 
-  univ_meta  : RBMap (UnivCid  .Meta) (Univ  .Meta) compare
-  expr_meta  : RBMap (ExprCid  .Meta) (Expr  .Meta) compare
-  const_meta : RBMap (ConstCid .Meta) (Const .Meta) compare
+  univ_meta  : RBMap (UnivCid  .meta) (Univ  .meta) compare
+  expr_meta  : RBMap (ExprCid  .meta) (Expr  .meta) compare
+  const_meta : RBMap (ConstCid .meta) (Const .meta) compare
   deriving Inhabited
 
 def Store.union (s s' : Store) : Store := ⟨

--- a/Yatima/Ipld/ToIpld.lean
+++ b/Yatima/Ipld/ToIpld.lean
@@ -10,42 +10,42 @@ namespace Yatima
 
 def Opaque.toIpld {k : Ipld.Kind} (d : Opaque) (typeCid valueCid: ExprCid) : Ipld.Opaque k :=
 match k with
-  | .Anon => ⟨(), d.lvls.length, typeCid.anon, valueCid.anon, d.safe⟩
-  | .Meta => ⟨d.name, d.lvls, typeCid.meta, valueCid.meta, ()⟩
+  | .anon => ⟨(), d.lvls.length, typeCid.anon, valueCid.anon, d.safe⟩
+  | .meta => ⟨d.name, d.lvls, typeCid.meta, valueCid.meta, ()⟩
 
 def Quotient.toIpld {k : Ipld.Kind} (d : Quotient) (typeCid : ExprCid) : Ipld.Quotient k :=
 match k with
-  | .Anon => ⟨(), d.lvls.length, typeCid.anon, d.kind⟩
-  | .Meta => ⟨d.name, d.lvls, typeCid.meta, ()⟩
+  | .anon => ⟨(), d.lvls.length, typeCid.anon, d.kind⟩
+  | .meta => ⟨d.name, d.lvls, typeCid.meta, ()⟩
 
 def Axiom.toIpld {k : Ipld.Kind} (d : Axiom) (typeCid : ExprCid) : Ipld.Axiom k :=
 match k with
-  | .Anon => ⟨(), d.lvls.length, typeCid.anon, d.safe⟩
-  | .Meta => ⟨d.name, d.lvls, typeCid.meta, ()⟩
+  | .anon => ⟨(), d.lvls.length, typeCid.anon, d.safe⟩
+  | .meta => ⟨d.name, d.lvls, typeCid.meta, ()⟩
 
 def Theorem.toIpld {k : Ipld.Kind} (d : Theorem) (typeCid valueCid : ExprCid) : Ipld.Theorem k :=
 match k with
-  | .Anon => ⟨(), d.lvls.length, typeCid.anon, valueCid.anon⟩
-  | .Meta => ⟨d.name, d.lvls, typeCid.meta, valueCid.meta⟩
+  | .anon => ⟨(), d.lvls.length, typeCid.anon, valueCid.anon⟩
+  | .meta => ⟨d.name, d.lvls, typeCid.meta, valueCid.meta⟩
 
 def Definition.toIpld {k : Ipld.Kind} (d : Definition) (typeCid valueCid : ExprCid) : Ipld.Definition k :=
 match k with
-  | .Anon => ⟨(), d.lvls.length, typeCid.anon, valueCid.anon, d.safety⟩
-  | .Meta => ⟨d.name, d.lvls, typeCid.meta, valueCid.meta, ()⟩
+  | .anon => ⟨(), d.lvls.length, typeCid.anon, valueCid.anon, d.safety⟩
+  | .meta => ⟨d.name, d.lvls, typeCid.meta, valueCid.meta, ()⟩
 
 def Constructor.toIpld {k : Ipld.Kind} (c : Constructor) (typeCid rhsCid : ExprCid) : Ipld.Constructor k :=
 match k with
-  | .Anon => ⟨(), c.lvls.length, typeCid.anon, c.idx, c.params, c.fields, rhsCid.anon, c.safe⟩
-  | .Meta => ⟨c.name, c.lvls, typeCid.meta, (), (), (), rhsCid.meta, ()⟩
+  | .anon => ⟨(), c.lvls.length, typeCid.anon, c.idx, c.params, c.fields, rhsCid.anon, c.safe⟩
+  | .meta => ⟨c.name, c.lvls, typeCid.meta, (), (), (), rhsCid.meta, ()⟩
 
 def RecursorRule.toIpld {k : Ipld.Kind} (r : RecursorRule) (ctorCid : ConstCid) (rhsCid : ExprCid) : Ipld.RecursorRule k :=
 match k with
-  | .Anon => ⟨ctorCid.anon, r.fields, rhsCid.anon⟩
-  | .Meta => ⟨ctorCid.meta, (), rhsCid.meta⟩
+  | .anon => ⟨ctorCid.anon, r.fields, rhsCid.anon⟩
+  | .meta => ⟨ctorCid.meta, (), rhsCid.meta⟩
 
 def ExtRecursor.toIpld {k : Ipld.Kind} (r : ExtRecursor) (typeCid : ExprCid) (rulesCids : List $ Ipld.RecursorRule k) : Ipld.Recursor .extr k :=
 match k with 
-  | .Anon =>
+  | .anon =>
     ⟨ ()
     , r.lvls.length
     , typeCid.anon
@@ -54,9 +54,8 @@ match k with
     , r.motives
     , r.minors
     , rulesCids
-    --, .inj₂ $ r.rules.enum.map $ fun (i, rule) => rule.toIpld rulesCids[i]!.1 rulesCids[i]!.2
     , r.k ⟩
-  | .Meta =>
+  | .meta =>
     ⟨ r.name
     , r.lvls
     , typeCid.meta
@@ -66,7 +65,7 @@ match k with
 
 def IntRecursor.toIpld {k : Ipld.Kind} (r : IntRecursor) (typeCid : ExprCid) : Ipld.Recursor .intr k :=
 match k with 
-  | .Anon =>
+  | .anon =>
     ⟨ ()
     , r.lvls.length
     , typeCid.anon
@@ -76,7 +75,7 @@ match k with
     , r.minors
     , .inj₁ ()
     , r.k ⟩
-  | .Meta =>
+  | .meta =>
     ⟨ r.name
     , r.lvls
     , typeCid.meta
@@ -86,13 +85,13 @@ match k with
 
 def Inductive.toIpld {k : Ipld.Kind} (i : Inductive) (idx : Nat) (typeCid : ExprCid) (blockCid : ConstCid) : Ipld.InductiveProj k :=
 match k with
-  | .Anon =>
+  | .anon =>
     ⟨ ()
     , i.lvls.length
     , typeCid.anon
     , blockCid.anon
     , idx ⟩
-  | .Meta =>
+  | .meta =>
     ⟨ i.name
     , i.lvls
     , typeCid.meta
@@ -100,6 +99,7 @@ match k with
     , () ⟩
 
 namespace Ipld
+
 instance : Coe Nat Ipld where
   coe x := .bytes x.toByteArrayBE
 
@@ -109,21 +109,20 @@ instance : Coe Bool Ipld where
 instance : Coe Name Ipld where
   coe x := .string (Lean.Name.toString x)
 
-
 instance : Coe (UnivCid k)  Ipld where coe u := .link u.data
 instance : Coe (ExprCid k)  Ipld where coe u := .link u.data
 instance : Coe (ConstCid k) Ipld where coe u := .link u.data
 
 instance [Coe α Ipld] [Coe β Ipld] : Coe (α ⊕ β) Ipld where coe
-  | .inl i => i
-  | .inr c => c
+  | .inl a => a
+  | .inr b => b
 
 instance [Coe α Ipld] : Coe (Option α) Ipld where coe
   | none   => .null
   | some a => a
 
 instance [Coe α Ipld] : Coe (List α) Ipld where
-  coe l := .array ⟨List.map (fun (x : α) => x) l⟩
+  coe l := .array ⟨l.map fun (x : α) => x⟩
 
 instance [Coe α Ipld] [Coe β Ipld] : Coe (α × β) Ipld where
   coe x := .array #[x.1, x.2]
@@ -156,8 +155,8 @@ instance : Coe Unit Ipld where coe
   | .unit => .array #[]
 
 instance : (k : Kind) → Coe (RecursorRule k) Ipld
-  | .Anon => { coe := fun | .mk c f r => .array #[c, f, r] }
-  | .Meta => { coe := fun | .mk c f r => .array #[c, f, r] }
+  | .anon => { coe := fun | .mk c f r => .array #[c, f, r] }
+  | .meta => { coe := fun | .mk c f r => .array #[c, f, r] }
 
 instance : Coe (Recursor b k) Ipld where coe
   | .mk n l t p i m m' rs k => .array #[n, l, t, p, i, m, m', rs, k]
@@ -181,6 +180,7 @@ instance : Coe (Definition k) Ipld where coe
   | .mk n l t v s => .array #[n, l, t, v, s]
 
 end Ipld
+
 namespace ToIpld
 
 def ipldToCid (codec: Nat) (ipld : Ipld): Cid :=
@@ -196,16 +196,16 @@ def univToIpld : (Ipld.Univ k) → Ipld
   | .var n i   => .array #[.number $ Ipld.UNIV k, .number 4, n, i]
 
 def exprToIpld : (Ipld.Expr k) → Ipld
-  | .var n i i' ls   => .array #[.number $ Ipld.EXPR k, .number 0, i, i', n, ls]
-  | .sort u       => .array #[.number $ Ipld.EXPR k, .number 1, u]
-  | .const n c ls => .array #[.number $ Ipld.EXPR k, .number 2, n, c, ls]
-  | .app f a      => .array #[.number $ Ipld.EXPR k, .number 3, f, a]
-  | .lam n i d b  => .array #[.number $ Ipld.EXPR k, .number 4, n, i, d, b]
-  | .pi n i d c   => .array #[.number $ Ipld.EXPR k, .number 5, n, i, d, c]
-  | .letE n t v b => .array #[.number $ Ipld.EXPR k, .number 6, n, t, v, b]
-  | .lit l        => .array #[.number $ Ipld.EXPR k, .number 7, l]
-  | .lty l        => .array #[.number $ Ipld.EXPR k, .number 8, l]
-  | .proj n e     => .array #[.number $ Ipld.EXPR k, .number 10, n, e]
+  | .var n i i' ls => .array #[.number $ Ipld.EXPR k, .number 0, i, i', n, ls]
+  | .sort u        => .array #[.number $ Ipld.EXPR k, .number 1, u]
+  | .const n c ls  => .array #[.number $ Ipld.EXPR k, .number 2, n, c, ls]
+  | .app f a       => .array #[.number $ Ipld.EXPR k, .number 3, f, a]
+  | .lam n i d b   => .array #[.number $ Ipld.EXPR k, .number 4, n, i, d, b]
+  | .pi n i d c    => .array #[.number $ Ipld.EXPR k, .number 5, n, i, d, c]
+  | .letE n t v b  => .array #[.number $ Ipld.EXPR k, .number 6, n, t, v, b]
+  | .lit l         => .array #[.number $ Ipld.EXPR k, .number 7, l]
+  | .lty l         => .array #[.number $ Ipld.EXPR k, .number 8, l]
+  | .proj n e      => .array #[.number $ Ipld.EXPR k, .number 10, n, e]
 
 def constToIpld : (Ipld.Const k) → Ipld
   | .axiom ⟨n, l, t, s⟩                 => .array #[.number $ Ipld.CONST k, .number 0,  n, l, t, s]
@@ -216,8 +216,8 @@ def constToIpld : (Ipld.Const k) → Ipld
   | .constructorProj ⟨n, l, t, b, i, j⟩ => .array #[.number $ Ipld.CONST k, .number 6, n, l, t, b, i, j]
   | .recursorProj ⟨n, l, t, b, i, j⟩    => .array #[.number $ Ipld.CONST k, .number 7, n, l, t, b, i, j]
   | .definitionProj ⟨n, l, t, b, i⟩     => .array #[.number $ Ipld.CONST k, .number 8, n, l, t, b, i]
-  | .mutDefBlock ds                    => .array #[.number $ Ipld.CONST k, .number 9,  ds]
-  | .mutIndBlock is                    => .array #[.number $ Ipld.CONST k, .number 10, is]
+  | .mutDefBlock ds                     => .array #[.number $ Ipld.CONST k, .number 9,  ds]
+  | .mutIndBlock is                     => .array #[.number $ Ipld.CONST k, .number 10, is]
 
 def univToCid (univ : Ipld.Univ k) : Ipld.UnivCid k :=
   { data := ipldToCid (Ipld.UNIV k).toNat (univToIpld univ) }
@@ -229,4 +229,5 @@ def constToCid (const : Ipld.Const k) : Ipld.ConstCid k :=
   { data := ipldToCid (Ipld.CONST k).toNat (constToIpld const) }
 
 end ToIpld
+
 end Yatima

--- a/Yatima/Transpiler/Test.lean
+++ b/Yatima/Transpiler/Test.lean
@@ -5,7 +5,7 @@ import Lean.Util.Path
 
 open System
 
-open Yatima.Compiler Yatima.FromIpld Yatima.Transpiler 
+open Yatima.Compiler Yatima.Converter Yatima.Transpiler 
 
 def test : IO Unit := do
   match (← compile "./Fixtures/LurkTranslation/SimplePrelude.lean") with 
@@ -18,4 +18,4 @@ def test : IO Unit := do
         IO.FS.writeFile fname s!"{out}"
         IO.print out
 
-#eval test
+-- #eval test

--- a/Yatima/Transpiler/TranspileM.lean
+++ b/Yatima/Transpiler/TranspileM.lean
@@ -1,4 +1,4 @@
-import Yatima.Ipld.FromIpld
+import Yatima.Converter.Converter
 import Yatima.Transpiler.TranspileError
 
 namespace Yatima.Transpiler
@@ -9,7 +9,7 @@ structure State where
   visited : Std.RBTree Name compare
   deriving Inhabited
 
-open Yatima.Compiler Yatima.FromIpld
+open Yatima.Compiler Yatima.Converter
 
 abbrev TranspileM := ReaderT CompileState $
   ExceptT TranspileError $ StateT State IO

--- a/Yatima/Transpiler/Transpiler.lean
+++ b/Yatima/Transpiler/Transpiler.lean
@@ -5,7 +5,8 @@ import Yatima.Transpiler.LurkFunctions
 
 namespace Yatima.Transpiler
 
-open Yatima.FromIpld
+open Yatima.Converter
+
 mutual
 
   partial def telescopeApp (expr : Expr) : TranspileM Lurk.Expr := 

--- a/Yatima/Typechecker/Typechecker.lean
+++ b/Yatima/Typechecker/Typechecker.lean
@@ -1,5 +1,5 @@
 import Yatima.Typechecker.TypecheckM
-import Yatima.Ipld.FromIpld
+import Yatima.Converter.Converter
 import Yatima.Datatypes.Store
 
 namespace Yatima.Typechecker
@@ -9,7 +9,7 @@ def typecheckM : TypecheckM Unit :=
   pure ()
 
 def typecheck (store : Ipld.Store) : Bool × Option String :=
-  match FromIpld.extractConstArray store with
+  match Converter.extractConstArray store with
   | .ok store => match TypecheckM.run (.init store) typecheckM with
     | .ok _ => (true, none)
     | .error msg => (false, some "toString msg")


### PR DESCRIPTION
`FromIpld` wasn't really the opposite of `ToIpld`, since no IPLD deserealization was being made.

Instead, we're converting the `Ipld.Store` to "pure" types (no CIDs involved) for typechecking and transpilation.